### PR TITLE
Add glass sheen to login inputs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,6 +19,227 @@ footer {
     bottom: 0;
     width: 100%;
 }
+
+/* Gamer login styling */
+.gamer-background {
+    position: relative;
+    min-height: 100vh;
+    background: radial-gradient(circle at 20% 20%, rgba(52, 211, 153, 0.18), transparent 25%),
+        radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.2), transparent 25%),
+        radial-gradient(circle at 50% 80%, rgba(168, 85, 247, 0.15), transparent 28%),
+        #050915;
+    color: #e5e7eb;
+    overflow: hidden;
+}
+
+.gamer-background::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+    background-size: 120px 120px;
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+.neon-orb {
+    position: absolute;
+    width: 240px;
+    height: 240px;
+    border-radius: 50%;
+    filter: blur(60px);
+    opacity: 0.6;
+}
+
+.neon-orb.green {
+    background: #22c55e;
+    top: -60px;
+    left: -60px;
+}
+
+.neon-orb.purple {
+    background: #a855f7;
+    bottom: -80px;
+    right: -50px;
+}
+
+.glass-card-login {
+    position: relative;
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 20px 70px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(18px);
+    border-radius: 20px;
+    padding: 2.5rem 2rem;
+    overflow: hidden;
+}
+
+.glass-card-login::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(34, 197, 94, 0.18), rgba(59, 130, 246, 0.18), rgba(167, 139, 250, 0.18));
+    opacity: 0.45;
+    filter: blur(30px);
+    z-index: 0;
+}
+
+.glass-card-login::after {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: 19px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    pointer-events: none;
+}
+
+.input-group {
+    position: relative;
+}
+
+.input-shell {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.9rem 1rem;
+    border-radius: 14px;
+    width: 100%;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 14px 38px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+    transition: all 0.25s ease;
+}
+
+.input-shell::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(34, 197, 94, 0.14), rgba(59, 130, 246, 0.12), rgba(167, 139, 250, 0.1));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+}
+
+.input-shell::after {
+    content: '';
+    position: absolute;
+    inset: 2px;
+    border-radius: 12px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06));
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.25), inset 0 -8px 18px rgba(15, 23, 42, 0.35);
+    pointer-events: none;
+    z-index: 1;
+}
+
+.input-shell:hover::before {
+    opacity: 0.4;
+}
+
+.input-shell:focus-within {
+    border-color: rgba(34, 197, 94, 0.5);
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.18), 0 18px 48px rgba(34, 197, 94, 0.24);
+}
+
+.input-shell:focus-within::before {
+    opacity: 0.6;
+}
+
+.input-icon {
+    position: relative;
+    z-index: 2;
+    color: #a5f3fc;
+    font-size: 1rem;
+    text-shadow: 0 0 10px rgba(165, 243, 252, 0.4);
+}
+
+.glass-input {
+    position: relative;
+    z-index: 2;
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: #f8fafc;
+    font-size: 1rem;
+    padding: 0;
+    outline: none;
+}
+
+.glass-input::placeholder {
+    color: rgba(226, 232, 240, 0.8);
+}
+
+.input-accent {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: linear-gradient(180deg, #22c55e, #22d3ee);
+    border-radius: 12px;
+    box-shadow: 0 0 16px rgba(34, 197, 94, 0.7);
+    opacity: 0.9;
+    transition: transform 0.25s ease;
+    z-index: 2;
+}
+
+.input-shell:focus-within .input-accent {
+    transform: translateX(-2px) scaleY(1.05);
+}
+
+.neon-button {
+    position: relative;
+    background: linear-gradient(120deg, #22c55e, #10b981, #22c55e);
+    color: #0b1021;
+    font-weight: 800;
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    box-shadow: 0 15px 35px rgba(16, 185, 129, 0.4);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.neon-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 20px 45px rgba(16, 185, 129, 0.5);
+}
+
+.neon-button:active {
+    transform: translateY(0);
+}
+
+.badge-soft {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(34, 197, 94, 0.12);
+    color: #bbf7d0;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    font-size: 0.85rem;
+}
+
+.divider-line {
+    height: 1px;
+    width: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.15), transparent);
+    margin: 1.5rem 0;
+}
+
+a.glass-link {
+    color: #86efac;
+    font-weight: 600;
+}
+
+a.glass-link:hover {
+    color: #a7f3d0;
+}
+
 .glass-card {
     background: rgba(255, 255, 255, 0.1);
     backdrop-filter: blur(10px);

--- a/pages/login.php
+++ b/pages/login.php
@@ -1,26 +1,58 @@
 <?php include('../includes/header.php'); ?>
-<div class="flex items-center justify-center min-h-screen bg-gray-900">
-    <div class="bg-gray-800 p-8 rounded-lg shadow-lg max-w-md w-full">
-        <div class="flex justify-center mb-6">
-            <img src="../img/logo.png" alt="Xbox Logo" class="w-24">
+<div class="gamer-background flex items-center justify-center">
+    <div class="neon-orb green"></div>
+    <div class="neon-orb purple"></div>
+
+    <div class="glass-card-login max-w-lg w-full mx-4">
+        <div class="relative z-10">
+            <div class="flex justify-between items-center mb-4">
+                <div class="badge-soft">
+                    <i class="fa-solid fa-circle-nodes"></i>
+                    <span>Xbox Live</span>
+                </div>
+                <div class="text-sm text-gray-300">Acesso gamer seguro</div>
+            </div>
+
+            <div class="flex items-center gap-3 mb-6">
+                <img src="../img/logo.png" alt="Xbox Logo" class="w-14 drop-shadow-lg">
+                <div>
+                    <p class="uppercase text-xs tracking-widest text-gray-300">Bem-vindo de volta</p>
+                    <h2 class="text-3xl font-extrabold text-white">Entre na sua conta</h2>
+                </div>
+            </div>
+
+            <form action="../actions/login_action.php" method="POST" class="space-y-5 relative z-10">
+                <div class="grid gap-4">
+                    <div class="input-group">
+                        <label for="username" class="block text-sm font-semibold text-gray-200 mb-2">Username</label>
+                        <div class="input-shell">
+                            <i class="fa-solid fa-user-astronaut input-icon"></i>
+                            <input type="text" name="username" id="username" placeholder="Seu username" required class="glass-input" />
+                            <span class="input-accent"></span>
+                        </div>
+                    </div>
+                    <div class="input-group">
+                        <label for="password" class="block text-sm font-semibold text-gray-200 mb-2">Senha</label>
+                        <div class="input-shell">
+                            <i class="fa-solid fa-lock input-icon"></i>
+                            <input type="password" name="password" id="password" placeholder="Sua senha" required class="glass-input" />
+                            <span class="input-accent"></span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="divider-line"></div>
+
+                <button type="submit" class="w-full neon-button">
+                    Entrar
+                </button>
+
+                <div class="text-center mt-5 text-sm text-gray-200">
+                    <span class="mr-2">Ainda não tem uma conta?</span>
+                    <a href="register.php" class="glass-link">Cadastre-se</a>
+                </div>
+            </form>
         </div>
-        <h2 class="text-3xl font-bold text-center text-green-400 mb-6">Entrar na sua Conta</h2>
-        <form action="../actions/login_action.php" method="POST" class="space-y-6">
-            <div>
-                <label for="username" class="block text-sm font-medium text-gray-300">Username</label>
-                <input type="text" name="username" id="username" placeholder="Seu username" required class="w-full px-4 py-2 rounded-md bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-green-400">
-            </div>
-            <div>
-                <label for="password" class="block text-sm font-medium text-gray-300">Senha</label>
-                <input type="password" name="password" id="password" placeholder="Sua senha" required class="w-full px-4 py-2 rounded-md bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-green-400">
-            </div>
-            <div>
-                <button type="submit" class="w-full bg-green-500 hover:bg-green-600 text-white py-2 rounded-md font-bold focus:outline-none focus:ring-2 focus:ring-green-400 transition duration-200">Entrar</button>
-            </div>
-            <div class="text-center mt-4">
-                <a href="register.php" class="text-sm text-green-400 hover:underline">Ainda não tem uma conta? Cadastre-se</a>
-            </div>
-        </form>
     </div>
 </div>
 <?php include('../includes/footer.php'); ?>


### PR DESCRIPTION
## Summary
- add an inner glass layer and refined border to the login inputs for a smoother card-like feel
- raise icons and accent bar above the glass overlay to keep them crisp
- slightly brighten placeholder text for better readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209229e5788326814c76d8b6fe5bc2)