### PR TITLE
Add liquid glass Xbox-inspired navbar styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,207 @@ footer {
     width: 100%;
 }
 
+/* Liquid glass inspired navbar */
+.liquid-nav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    padding: 1rem 0;
+    backdrop-filter: blur(22px) saturate(160%);
+    background: linear-gradient(115deg, rgba(10, 24, 10, 0.72) 0%, rgba(12, 43, 15, 0.82) 45%, rgba(16, 124, 16, 0.65) 100%);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    overflow: hidden;
+}
+
+.nav-glass-overlay {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 30%, rgba(108, 198, 68, 0.18), transparent 45%),
+        radial-gradient(circle at 80% 10%, rgba(82, 176, 67, 0.12), transparent 35%),
+        linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent 30%, rgba(255, 255, 255, 0.04));
+    mix-blend-mode: screen;
+    pointer-events: none;
+}
+
+.nav-grid {
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: 120px 120px;
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+.nav-orb {
+    position: absolute;
+    width: 320px;
+    height: 320px;
+    border-radius: 50%;
+    filter: blur(70px);
+    opacity: 0.5;
+    animation: xboxOrbitFloat 16s ease-in-out infinite;
+}
+
+.nav-orb-left {
+    background: radial-gradient(circle, #52b043, #0e7a0e);
+    top: -120px;
+    left: -60px;
+}
+
+.nav-orb-right {
+    background: radial-gradient(circle, #8bd682, #52b043);
+    bottom: -140px;
+    right: 0;
+    animation-delay: 4s;
+}
+
+.nav-brand-text {
+    color: #e6ffed;
+    font-weight: 800;
+    letter-spacing: 0.5px;
+    text-shadow: 0 4px 18px rgba(82, 176, 67, 0.4);
+}
+
+.nav-brand-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.nav-item {
+    position: relative;
+}
+
+.nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: #e6ffed;
+    padding: 0.65rem 0.85rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(108, 198, 68, 0.6);
+    box-shadow: 0 12px 30px rgba(16, 124, 16, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+    transform: translateY(-1px);
+}
+
+.nav-dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    min-width: 220px;
+    background: rgba(5, 12, 8, 0.86);
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(20px) saturate(160%);
+    overflow: hidden;
+    z-index: 30;
+}
+
+.nav-dropdown-item {
+    display: flex;
+    align-items: center;
+    color: #f1fff6;
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-dropdown-item:hover {
+    background: rgba(82, 176, 67, 0.16);
+    color: #d9ffe4;
+}
+
+.nav-search {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    border: 1px solid rgba(108, 198, 68, 0.4);
+    backdrop-filter: blur(14px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.nav-search-input {
+    background: transparent;
+    border: none;
+    color: #e6ffed;
+    outline: none;
+    min-width: 180px;
+}
+
+.nav-search-input::placeholder {
+    color: rgba(230, 255, 237, 0.65);
+}
+
+.nav-search-button {
+    background: linear-gradient(135deg, #52b043 0%, #107c10 100%);
+    color: white;
+    font-weight: 700;
+    padding: 0.5rem 0.85rem;
+    border-radius: 12px;
+    border: 1px solid rgba(82, 176, 67, 0.6);
+    box-shadow: 0 8px 20px rgba(16, 124, 16, 0.35);
+    transition: all 0.2s ease;
+}
+
+.nav-search-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 28px rgba(16, 124, 16, 0.45);
+    background: linear-gradient(135deg, #6cc644 0%, #34a532 100%);
+}
+
+.nav-profile {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.5rem 0.8rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    color: #e6ffed;
+}
+
+.nav-profile-ring {
+    position: absolute;
+    inset: -2px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.7), rgba(16, 124, 16, 0.6));
+    opacity: 0.35;
+    filter: blur(14px);
+    pointer-events: none;
+}
+
+.nav-profile-img {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 2px solid rgba(82, 176, 67, 0.7);
+    box-shadow: 0 0 18px rgba(82, 176, 67, 0.45);
+    object-fit: cover;
+}
+
+.nav-profile-name {
+    font-weight: 700;
+    text-shadow: 0 4px 14px rgba(82, 176, 67, 0.4);
+}
+
 /* Liquid Glass Login Effect */
 .liquid-background {
     position: relative;

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -1,14 +1,14 @@
 <?php
     require '../config/db.php';
     require_once '../config/api.php';
-    
+
     // Obter dados da conta diretamente da API (não depende de xuid no banco)
     $endpoint = "account";
     $response = openXBLRequest($endpoint);
-    
+
     $gamerpic = '../img/default_avatar.jpg';
     $gamertag = 'Usuário';
-    
+
     if ($response && isset($response['profileUsers'][0]['settings'])) {
         $settings = $response['profileUsers'][0]['settings'];
         foreach ($settings as $setting) {
@@ -21,103 +21,120 @@
         }
     }
 ?>
-<nav class="bg-gray-800 p-4">
-    <div class="flex justify-between items-center">
+<nav class="liquid-nav relative">
+    <div class="nav-glass-overlay"></div>
+    <div class="nav-grid"></div>
+    <div class="nav-orb nav-orb-left"></div>
+    <div class="nav-orb nav-orb-right"></div>
+
+    <div class="relative z-10 flex justify-between items-center max-w-7xl mx-auto px-4">
         <div class="flex items-center space-x-4">
-            <a href="dashboard.php">
-                <img src="../img/logo2.png" alt="Xbox Logo" class="w-10 h-10">
+            <a href="dashboard.php" class="nav-brand flex items-center space-x-3">
+                <span class="nav-brand-icon grid place-items-center">
+                    <img src="../img/logo2.png" alt="Xbox Logo" class="w-10 h-10">
+                </span>
+                <span class="nav-brand-text">Xbox Live</span>
             </a>
-            <div class="relative">
-                <button id="dropdown-amigos-btn" class="text-white hover:text-gray-400 focus:outline-none">
+
+            <div class="relative nav-item">
+                <button id="dropdown-amigos-btn" class="nav-link">
                     <i class="fas fa-user-friends mr-2"></i> Amigos
-                    <i class="fas fa-chevron-down ml-1"></i>
+                    <i class="fas fa-chevron-down ml-1 text-xs"></i>
                 </button>
-                <div id="dropdown-amigos-menu" class="hidden absolute bg-gray-700 text-white rounded-lg shadow-lg mt-2">
-                    <a href="../pages/amigos.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                <div id="dropdown-amigos-menu" class="nav-dropdown hidden">
+                    <a href="../pages/amigos.php" class="nav-dropdown-item">
                         <i class="fas fa-users mr-2"></i> Amigos
                     </a>
-                    <a href="../pages/bloqueados.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/bloqueados.php" class="nav-dropdown-item">
                         <i class="fas fa-ban mr-2"></i> Bloqueados
                     </a>
-                    <a href="../pages/recentes.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/recentes.php" class="nav-dropdown-item">
                         <i class="fas fa-history mr-2"></i> Recentes
                     </a>
                 </div>
             </div>
-            <div class="relative">
-                <button id="dropdown-activity-btn" class="text-white flex items-center hover:text-gray-400 focus:outline-none">
+
+            <div class="relative nav-item">
+                <button id="dropdown-activity-btn" class="nav-link">
                     <i class="fas fa-stream mr-2"></i> Atividade
-                    <i class="fas fa-chevron-down ml-1"></i>
+                    <i class="fas fa-chevron-down ml-1 text-xs"></i>
                 </button>
-                <div id="dropdown-activity-menu" class="hidden absolute bg-gray-700 text-white rounded-lg shadow-lg mt-2">
-                    <a href="../pages/feed.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                <div id="dropdown-activity-menu" class="nav-dropdown hidden">
+                    <a href="../pages/feed.php" class="nav-dropdown-item">
                         <i class="fas fa-rss mr-2"></i> Feed
                     </a>
-                    <a href="../pages/historico.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/historico.php" class="nav-dropdown-item">
                         <i class="fas fa-history mr-2"></i> Histórico
                     </a>
                 </div>
             </div>
-            <a href="conquistas.php" class="text-white flex items-center hover:text-gray-400">
+
+            <a href="conquistas.php" class="nav-link">
                 <i class="fas fa-trophy mr-2"></i> Conquistas
             </a>
-            <div class="relative">
-                <button id="dropdown-gamepass-btn" class="text-white flex items-center hover:text-gray-400 focus:outline-none">
+
+            <div class="relative nav-item">
+                <button id="dropdown-gamepass-btn" class="nav-link">
                     <i class="fas fa-gamepad mr-2"></i> Gamepass
-                    <i class="fas fa-chevron-down ml-1"></i>
+                    <i class="fas fa-chevron-down ml-1 text-xs"></i>
                 </button>
-                <div id="dropdown-gamepass-menu" class="hidden absolute bg-gray-700 text-white rounded-lg shadow-lg mt-2">
-                    <a href="../pages/todos_os_jogos.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                <div id="dropdown-gamepass-menu" class="nav-dropdown hidden">
+                    <a href="../pages/todos_os_jogos.php" class="nav-dropdown-item">
                         <i class="fas fa-list mr-2"></i> Todos os Jogos
                     </a>
-                    <a href="../pages/ea_play.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/ea_play.php" class="nav-dropdown-item">
                         <i class="fas fa-play-circle mr-2"></i> EA Play
                     </a>
-                    <a href="../pages/jogos_sem_controle.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/jogos_sem_controle.php" class="nav-dropdown-item">
                         <i class="fas fa-gamepad mr-2"></i> Jogos sem Controle
                     </a>
-                    <a href="../pages/gamepass_pc.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/gamepass_pc.php" class="nav-dropdown-item">
                         <i class="fas fa-laptop mr-2"></i> PC Gamepass
                     </a>
                 </div>
             </div>
-            <div class="relative">
-                <button id="dropdown-loja-btn" class="text-white flex items-center hover:text-gray-400 focus:outline-none">
+
+            <div class="relative nav-item">
+                <button id="dropdown-loja-btn" class="nav-link">
                     <i class="fas fa-store mr-2"></i> Loja
-                    <i class="fas fa-chevron-down ml-1"></i>
+                    <i class="fas fa-chevron-down ml-1 text-xs"></i>
                 </button>
-                <div id="dropdown-loja-menu" class="hidden absolute bg-gray-700 text-white rounded-lg shadow-lg mt-2">
-                    <a href="../pages/em_breve.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                <div id="dropdown-loja-menu" class="nav-dropdown hidden">
+                    <a href="../pages/em_breve.php" class="nav-dropdown-item">
                         <i class="fas fa-hourglass-start mr-2"></i> Em Breve
                     </a>
-                    <a href="../pages/mais_jogados.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/mais_jogados.php" class="nav-dropdown-item">
                         <i class="fas fa-fire mr-2"></i> Mais Jogados
                     </a>
-                    <a href="../pages/melhores_avaliados.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/melhores_avaliados.php" class="nav-dropdown-item">
                         <i class="fas fa-star mr-2"></i> Melhores Avaliados
                     </a>
-                    <a href="../pages/novos_jogos.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/novos_jogos.php" class="nav-dropdown-item">
                         <i class="fas fa-plus-circle mr-2"></i> Novos Jogos
                     </a>
-                    <a href="../pages/populares_gratis.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/populares_gratis.php" class="nav-dropdown-item">
                         <i class="fas fa-gift mr-2"></i> Populares Grátis
                     </a>
-                    <a href="../pages/populares_pagos.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/populares_pagos.php" class="nav-dropdown-item">
                         <i class="fas fa-dollar-sign mr-2"></i> Populares Pagos
                     </a>
-                    <a href="../pages/promocao.php" class="block px-4 py-2 hover:bg-gray-600 flex items-center">
+                    <a href="../pages/promocao.php" class="nav-dropdown-item">
                         <i class="fas fa-tags mr-2"></i> Promoção
                     </a>
                 </div>
             </div>
         </div>
+
         <div class="flex items-center space-x-4">
-            <form action="search.php" method="GET" class="flex items-center">
-                <input type="text" name="gamertag_search" placeholder="Buscar Gamertag" class="px-4 py-2 rounded-lg bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-green-400" required>
-                <button type="submit" class="ml-2 bg-green-500 text-white px-4 py-2 rounded-lg">Buscar</button>
+            <form action="search.php" method="GET" class="nav-search">
+                <i class="fas fa-search text-green-200"></i>
+                <input type="text" name="gamertag_search" placeholder="Buscar Gamertag" class="nav-search-input" required>
+                <button type="submit" class="nav-search-button">Buscar</button>
             </form>
-            <button class="focus:outline-none">
-                <img src="<?php echo $gamerpic; ?>" alt="Profile" class="w-10 h-10 rounded-full border-2 border-green-500" id="user-menu-button">
+            <button class="focus:outline-none nav-profile" id="user-menu-button">
+                <div class="nav-profile-ring"></div>
+                <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
+                <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
             </button>
         </div>
     </div>
@@ -134,8 +151,5 @@
     });
     document.getElementById('dropdown-loja-btn').addEventListener('click', function() {
         document.getElementById('dropdown-loja-menu').classList.toggle('hidden');
-    });
-    document.getElementById('user-menu-button').addEventListener('click', function() {
-        document.getElementById('user-menu').classList.toggle('hidden');
     });
 </script>


### PR DESCRIPTION
## Summary
- restyle the navbar with an iOS 16/17-inspired liquid glass look tuned to the Xbox palette and add floating glow elements
- update navigation links, dropdowns, search bar, and profile chip to use glassmorphic controls and gradients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b6adb13c83269af202c3fe39fddf)