### PR TITLE
Adjust navbar layout and dropdown interactions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,222 @@ html, body {
     height: 100%;
     margin: 0;
 }
+
+:root {
+    --xbox-green: #52b043;
+    --xbox-green-strong: #107c10;
+    --xbox-surface: rgba(255, 255, 255, 0.08);
+    --xbox-border: rgba(82, 176, 67, 0.35);
+    --xbox-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.xbox-body {
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(82, 176, 67, 0.2), transparent 35%),
+        radial-gradient(circle at 80% 0%, rgba(16, 124, 16, 0.25), transparent 30%),
+        linear-gradient(135deg, #050f08 0%, #0b1c0d 40%, #071407 100%);
+    color: #e6ffed;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    overflow-x: hidden;
+}
+
+.xbox-body::before,
+.xbox-body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.xbox-body::before {
+    background:
+        radial-gradient(circle at 15% 75%, rgba(82, 176, 67, 0.25), transparent 35%),
+        radial-gradient(circle at 85% 30%, rgba(108, 198, 68, 0.22), transparent 38%),
+        radial-gradient(circle at 60% 80%, rgba(16, 124, 16, 0.18), transparent 42%);
+    filter: blur(40px);
+    opacity: 0.8;
+}
+
+.xbox-body::after {
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: 140px 140px;
+    opacity: 0.18;
+}
+
+.xbox-body > * {
+    position: relative;
+    z-index: 1;
+}
+
+.xbox-content {
+    flex: 1 0 auto;
+    padding: 2.5rem 1.25rem 3rem;
+}
+
+.xbox-page {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.xbox-hero {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.xbox-hero-eyebrow {
+    color: rgba(230, 255, 237, 0.8);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    font-size: 0.85rem;
+}
+
+.xbox-hero-title {
+    font-size: clamp(2.1rem, 3vw, 2.75rem);
+    font-weight: 800;
+    line-height: 1.1;
+    text-shadow: 0 6px 24px rgba(82, 176, 67, 0.35);
+}
+
+.xbox-hero-subtitle {
+    color: rgba(230, 255, 237, 0.78);
+    max-width: 720px;
+    font-size: 1rem;
+}
+
+.xbox-panel {
+    position: relative;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1.5px solid var(--xbox-border);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: var(--xbox-shadow);
+    backdrop-filter: blur(18px) saturate(150%);
+    overflow: hidden;
+}
+
+.xbox-panel::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(82, 176, 67, 0.12), transparent 55%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.xbox-panel h2 {
+    font-size: 1.35rem;
+    font-weight: 800;
+    color: #e6ffed;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.xbox-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(82, 176, 67, 0.15);
+    color: #d9ffe4;
+    padding: 0.45rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid var(--xbox-border);
+    font-weight: 700;
+    font-size: 0.95rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.xbox-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.25), rgba(16, 124, 16, 0.35));
+    border: 1px solid var(--xbox-border);
+    color: #e6ffed;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+
+.xbox-stat-list {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.9rem;
+    color: rgba(230, 255, 237, 0.9);
+}
+
+.xbox-stat-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.9rem 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(82, 176, 67, 0.22);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.xbox-stat-label {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-weight: 700;
+}
+
+.xbox-stat-value {
+    font-weight: 800;
+    color: #7fe391;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.xbox-avatar {
+    width: 88px;
+    height: 88px;
+    border-radius: 18px;
+    object-fit: cover;
+    border: 2px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.35);
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.xbox-footer {
+    position: relative;
+    margin-top: auto;
+    padding: 1.5rem 1rem;
+    background: rgba(5, 12, 8, 0.9);
+    border-top: 1px solid var(--xbox-border);
+    color: #e6ffed;
+    box-shadow: 0 -12px 32px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+
+.xbox-footer::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 10%, rgba(82, 176, 67, 0.25), transparent 50%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.xbox-footer .xbox-footer-content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+}
 #container {
     min-height: 100%;
     display: flex;
@@ -11,8 +227,8 @@ html, body {
     flex: 1;
 }
 footer {
-    background-color: #1a202c;
-    color: white;
+    background: transparent;
+    color: inherit;
     text-align: center;
     padding: 10px 0;
     position: relative;
@@ -29,7 +245,7 @@ footer {
     backdrop-filter: blur(22px) saturate(160%);
     background: linear-gradient(115deg, rgba(10, 24, 10, 0.72) 0%, rgba(12, 43, 15, 0.82) 45%, rgba(16, 124, 16, 0.65) 100%);
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    overflow: hidden;
+    overflow: visible;
 }
 
 .nav-glass-overlay {
@@ -146,8 +362,8 @@ footer {
 .nav-search {
     display: inline-flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.6rem 0.75rem;
+    gap: 0.55rem;
+    padding: 0.5rem 0.65rem;
     background: rgba(255, 255, 255, 0.08);
     border-radius: 14px;
     border: 1px solid rgba(108, 198, 68, 0.4);
@@ -160,7 +376,8 @@ footer {
     border: none;
     color: #e6ffed;
     outline: none;
-    min-width: 180px;
+    min-width: 150px;
+    font-size: 0.95rem;
 }
 
 .nav-search-input::placeholder {
@@ -171,7 +388,7 @@ footer {
     background: linear-gradient(135deg, #52b043 0%, #107c10 100%);
     color: white;
     font-weight: 700;
-    padding: 0.5rem 0.85rem;
+    padding: 0.45rem 0.75rem;
     border-radius: 12px;
     border: 1px solid rgba(82, 176, 67, 0.6);
     box-shadow: 0 8px 20px rgba(16, 124, 16, 0.35);
@@ -219,6 +436,39 @@ footer {
 .nav-profile-name {
     font-weight: 700;
     text-shadow: 0 4px 14px rgba(82, 176, 67, 0.4);
+    max-width: 140px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nav-profile-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.5rem);
+    min-width: 160px;
+    background: rgba(5, 12, 8, 0.9);
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    border-radius: 14px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(18px) saturate(150%);
+    overflow: hidden;
+    z-index: 40;
+}
+
+.nav-profile-menu a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    color: #e6ffed;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-profile-menu a:hover {
+    background: rgba(82, 176, 67, 0.16);
+    color: #d9ffe4;
 }
 
 /* Liquid Glass Login Effect */

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,8 +1,8 @@
-        <footer class="bg-gray-800 text-white py-4 mt-auto">
-            <div class="text-center">
+        <footer class="xbox-footer">
+            <div class="xbox-footer-content">
                 <p>&copy; 2025 Xbox. Todos os direitos reservados.</p>
             </div>
         </footer>
-        </body>
+    </body>
 
-        </html>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -10,4 +10,4 @@
         <link rel="icon" type="image/png" href="../img/logo2.png"/>
         <title>Xbox</title>
     </head>
-    <body class="bg-gray-100 flex flex-col min-h-screen">
+    <body class="xbox-body">

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -125,31 +125,61 @@
             </div>
         </div>
 
-        <div class="flex items-center space-x-4">
+        <div class="flex items-center space-x-4 ml-4 lg:ml-6">
             <form action="search.php" method="GET" class="nav-search">
                 <i class="fas fa-search text-green-200"></i>
                 <input type="text" name="gamertag_search" placeholder="Buscar Gamertag" class="nav-search-input" required>
                 <button type="submit" class="nav-search-button">Buscar</button>
             </form>
-            <button class="focus:outline-none nav-profile" id="user-menu-button">
-                <div class="nav-profile-ring"></div>
-                <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
-                <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
-            </button>
+            <div class="relative">
+                <button class="focus:outline-none nav-profile" id="user-menu-button">
+                    <div class="nav-profile-ring"></div>
+                    <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
+                    <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
+                    <i class="fas fa-chevron-down text-xs"></i>
+                </button>
+                <div id="user-menu" class="nav-profile-menu hidden">
+                    <a href="../pages/logout.php">
+                        <i class="fas fa-sign-out-alt"></i> Sair
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
 </nav>
 <script>
-    document.getElementById('dropdown-amigos-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-amigos-menu').classList.toggle('hidden');
+    const dropdowns = [
+        { button: 'dropdown-amigos-btn', menu: 'dropdown-amigos-menu' },
+        { button: 'dropdown-activity-btn', menu: 'dropdown-activity-menu' },
+        { button: 'dropdown-gamepass-btn', menu: 'dropdown-gamepass-menu' },
+        { button: 'dropdown-loja-btn', menu: 'dropdown-loja-menu' },
+        { button: 'user-menu-button', menu: 'user-menu' }
+    ];
+
+    dropdowns.forEach(({ button, menu }) => {
+        const btn = document.getElementById(button);
+        const menuEl = document.getElementById(menu);
+
+        if (btn && menuEl) {
+            btn.addEventListener('click', (event) => {
+                event.stopPropagation();
+                const isHidden = menuEl.classList.contains('hidden');
+                closeAllDropdowns();
+                if (isHidden) {
+                    menuEl.classList.remove('hidden');
+                }
+            });
+        }
     });
-    document.getElementById('dropdown-activity-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-activity-menu').classList.toggle('hidden');
-    });
-    document.getElementById('dropdown-gamepass-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-gamepass-menu').classList.toggle('hidden');
-    });
-    document.getElementById('dropdown-loja-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-loja-menu').classList.toggle('hidden');
-    });
+
+    document.addEventListener('click', closeAllDropdowns);
+
+    function closeAllDropdowns() {
+        dropdowns.forEach(({ menu }) => {
+            const el = document.getElementById(menu);
+            if (el && !el.classList.contains('hidden')) {
+                el.classList.add('hidden');
+            }
+        });
+    }
 </script>

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -6,84 +6,110 @@
     $endpoint = "account";
     $response = openXBLRequest($endpoint);
     $profileUsers = (is_array($response) && isset($response['profileUsers'][0])) ? $response['profileUsers'][0] : null;
+
     $gamertag = null;
-    if ($profileUsers && isset($profileUsers['settings']) && is_array($profileUsers['settings'])) {
-        foreach ($profileUsers['settings'] as $setting) {
-            if (isset($setting['id']) && $setting['id'] === 'Gamertag') {
-                $gamertag = $setting['value'] ?? null;
-                break;
+    $settings = $profileUsers['settings'] ?? [];
+    $gamerpic = '../img/default_avatar.jpg';
+    $gamerscoreDisplay = '-';
+    $showGamerscoreIcon = false;
+    $accountTier = '-';
+    $reputation = '-';
+    $bio = '-';
+
+    if ($profileUsers && is_array($settings)) {
+        foreach ($settings as $setting) {
+            $id = $setting['id'] ?? null;
+            $value = $setting['value'] ?? null;
+
+            if ($id === 'Gamertag') {
+                $gamertag = $value;
+            }
+
+            if ($id === 'GameDisplayPicRaw') {
+                $gamerpic = $value;
+            }
+
+            if ($id === 'Gamerscore' && is_numeric($value)) {
+                $gamerscoreDisplay = $value >= 1000 ? number_format($value, 0, '', '.') : $value;
+                $showGamerscoreIcon = true;
+            }
+
+            if ($id === 'AccountTier') {
+                $accountTier = $value ?: '-';
+            }
+
+            if ($id === 'XboxOneRep') {
+                $reputation = $value ?: '-';
+            }
+
+            if ($id === 'Bio') {
+                $bio = $value ?: '-';
             }
         }
     }
 ?>
-<div class="container mx-auto mt-10 flex justify-center">
-    <div class="bg-white/30 backdrop-blur-lg p-8 rounded-lg shadow-lg border border-white/20 max-w-lg text-center">
-        <h1 class="text-4xl font-bold mb-4 text-black">Bem-vindo, <span class="text-green-500"><?php echo htmlspecialchars($gamertag); ?></span>!</h1>
-        <ul class="text-left text-black space-y-3">
-            <li><span class="text-green-500 font-bold">Gamerscore:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'Gamerscore') {
-                            $gamerscore = $setting['value'] ?? null;
-                            if (is_numeric($gamerscore)) {
-                                if ($gamerscore >= 1000) {
-                                    echo number_format($gamerscore, 0, '', '.') . ' ';
-                                } else {
-                                    echo $gamerscore . ' ';
-                                }
-                                echo '<img src="../img/gs.png" alt="Gamerscore Icon" class="inline w-5 h-5">';
-                            } else {
-                                echo '-';
-                            }
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Conta:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'AccountTier') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Reputação:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'XboxOneRep') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Bio:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'Bio') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-        </ul>
+<main class="xbox-content">
+    <div class="xbox-page">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Painel</span>
+            <h1 class="xbox-hero-title">Bem-vindo, <span class="text-green-400"><?php echo htmlspecialchars($gamertag); ?></span>!</h1>
+            <p class="xbox-hero-subtitle">Um resumo líquido e iluminado do seu perfil para manter a identidade visual alinhada com a página de login.</p>
+        </section>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="xbox-panel">
+                <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+                    <h2>
+                        <span class="xbox-icon"><i class="fas fa-id-card"></i></span>
+                        Identidade Xbox
+                    </h2>
+                    <span class="xbox-pill"><i class="fas fa-check"></i> Perfil ativo</span>
+                </div>
+
+                <ul class="xbox-stat-list">
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-medal text-green-400"></i> Gamerscore</span>
+                        <span class="xbox-stat-value">
+                            <?php echo htmlspecialchars($gamerscoreDisplay); ?>
+                            <?php if ($showGamerscoreIcon): ?>
+                                <img src="../img/gs.png" alt="Gamerscore Icon" class="inline w-5 h-5">
+                            <?php endif; ?>
+                        </span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-shield-alt text-green-400"></i> Conta</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($accountTier); ?></span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-thumbs-up text-green-400"></i> Reputação</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($reputation); ?></span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-quote-left text-green-400"></i> Bio</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($bio); ?></span>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="xbox-panel flex flex-col gap-4">
+                <div class="flex items-center gap-4 flex-wrap">
+                    <div class="xbox-icon">
+                        <i class="fas fa-user-circle"></i>
+                    </div>
+                    <div>
+                        <h2 class="mb-1">Seu perfil</h2>
+                        <p class="xbox-hero-subtitle text-sm">Detalhes rápidos em um cartão translúcido para manter a experiência consistente.</p>
+                    </div>
+                </div>
+                <div class="flex items-center gap-4 flex-wrap">
+                    <img src="<?php echo htmlspecialchars($gamerpic); ?>" alt="Avatar" class="xbox-avatar">
+                    <div class="space-y-2">
+                        <span class="xbox-pill"><i class="fas fa-user"></i> <?php echo htmlspecialchars($gamertag ?? 'Jogador'); ?></span>
+                        <div class="text-sm text-green-100/80">Personalize seu perfil e conquiste mais com o novo visual.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-</div>
-<br>
+</main>
 <?php include('../includes/footer.php'); ?>


### PR DESCRIPTION
## Summary
- resize the search bar and spacing to better match navbar buttons and separate it from the Loja menu
- allow dropdowns to render outside the navbar and add a profile menu with ellipsis-safe gamertags and a Sair action
- centralize dropdown toggling logic so menus open reliably and close when clicking elsewhere

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ba26d99c832693b5f9d91f36d389)