### PR TITLE
Refine blocked friends and recent players styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,222 @@ html, body {
     height: 100%;
     margin: 0;
 }
+
+:root {
+    --xbox-green: #52b043;
+    --xbox-green-strong: #107c10;
+    --xbox-surface: rgba(255, 255, 255, 0.08);
+    --xbox-border: rgba(82, 176, 67, 0.35);
+    --xbox-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.xbox-body {
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(82, 176, 67, 0.2), transparent 35%),
+        radial-gradient(circle at 80% 0%, rgba(16, 124, 16, 0.25), transparent 30%),
+        linear-gradient(135deg, #050f08 0%, #0b1c0d 40%, #071407 100%);
+    color: #e6ffed;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    overflow-x: hidden;
+}
+
+.xbox-body::before,
+.xbox-body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.xbox-body::before {
+    background:
+        radial-gradient(circle at 15% 75%, rgba(82, 176, 67, 0.25), transparent 35%),
+        radial-gradient(circle at 85% 30%, rgba(108, 198, 68, 0.22), transparent 38%),
+        radial-gradient(circle at 60% 80%, rgba(16, 124, 16, 0.18), transparent 42%);
+    filter: blur(40px);
+    opacity: 0.8;
+}
+
+.xbox-body::after {
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: 140px 140px;
+    opacity: 0.18;
+}
+
+.xbox-body > * {
+    position: relative;
+    z-index: 1;
+}
+
+.xbox-content {
+    flex: 1 0 auto;
+    padding: 2.5rem 1.25rem 3rem;
+}
+
+.xbox-page {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.xbox-hero {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.xbox-hero-eyebrow {
+    color: rgba(230, 255, 237, 0.8);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    font-size: 0.85rem;
+}
+
+.xbox-hero-title {
+    font-size: clamp(2.1rem, 3vw, 2.75rem);
+    font-weight: 800;
+    line-height: 1.1;
+    text-shadow: 0 6px 24px rgba(82, 176, 67, 0.35);
+}
+
+.xbox-hero-subtitle {
+    color: rgba(230, 255, 237, 0.78);
+    max-width: 720px;
+    font-size: 1rem;
+}
+
+.xbox-panel {
+    position: relative;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1.5px solid var(--xbox-border);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: var(--xbox-shadow);
+    backdrop-filter: blur(18px) saturate(150%);
+    overflow: hidden;
+}
+
+.xbox-panel::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(82, 176, 67, 0.12), transparent 55%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.xbox-panel h2 {
+    font-size: 1.35rem;
+    font-weight: 800;
+    color: #e6ffed;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.xbox-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(82, 176, 67, 0.15);
+    color: #d9ffe4;
+    padding: 0.45rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid var(--xbox-border);
+    font-weight: 700;
+    font-size: 0.95rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.xbox-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.25), rgba(16, 124, 16, 0.35));
+    border: 1px solid var(--xbox-border);
+    color: #e6ffed;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+
+.xbox-stat-list {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.9rem;
+    color: rgba(230, 255, 237, 0.9);
+}
+
+.xbox-stat-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.9rem 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(82, 176, 67, 0.22);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.xbox-stat-label {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-weight: 700;
+}
+
+.xbox-stat-value {
+    font-weight: 800;
+    color: #7fe391;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.xbox-avatar {
+    width: 88px;
+    height: 88px;
+    border-radius: 18px;
+    object-fit: cover;
+    border: 2px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.35);
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.xbox-footer {
+    position: relative;
+    margin-top: auto;
+    padding: 1.5rem 1rem;
+    background: rgba(5, 12, 8, 0.9);
+    border-top: 1px solid var(--xbox-border);
+    color: #e6ffed;
+    box-shadow: 0 -12px 32px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+
+.xbox-footer::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 10%, rgba(82, 176, 67, 0.25), transparent 50%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.xbox-footer .xbox-footer-content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+}
 #container {
     min-height: 100%;
     display: flex;
@@ -11,8 +227,8 @@ html, body {
     flex: 1;
 }
 footer {
-    background-color: #1a202c;
-    color: white;
+    background: transparent;
+    color: inherit;
     text-align: center;
     padding: 10px 0;
     position: relative;
@@ -29,7 +245,7 @@ footer {
     backdrop-filter: blur(22px) saturate(160%);
     background: linear-gradient(115deg, rgba(10, 24, 10, 0.72) 0%, rgba(12, 43, 15, 0.82) 45%, rgba(16, 124, 16, 0.65) 100%);
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    overflow: hidden;
+    overflow: visible;
 }
 
 .nav-glass-overlay {
@@ -146,8 +362,8 @@ footer {
 .nav-search {
     display: inline-flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.6rem 0.75rem;
+    gap: 0.55rem;
+    padding: 0.5rem 0.65rem;
     background: rgba(255, 255, 255, 0.08);
     border-radius: 14px;
     border: 1px solid rgba(108, 198, 68, 0.4);
@@ -160,7 +376,8 @@ footer {
     border: none;
     color: #e6ffed;
     outline: none;
-    min-width: 180px;
+    min-width: 150px;
+    font-size: 0.95rem;
 }
 
 .nav-search-input::placeholder {
@@ -171,7 +388,7 @@ footer {
     background: linear-gradient(135deg, #52b043 0%, #107c10 100%);
     color: white;
     font-weight: 700;
-    padding: 0.5rem 0.85rem;
+    padding: 0.45rem 0.75rem;
     border-radius: 12px;
     border: 1px solid rgba(82, 176, 67, 0.6);
     box-shadow: 0 8px 20px rgba(16, 124, 16, 0.35);
@@ -219,6 +436,39 @@ footer {
 .nav-profile-name {
     font-weight: 700;
     text-shadow: 0 4px 14px rgba(82, 176, 67, 0.4);
+    max-width: 140px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nav-profile-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.5rem);
+    min-width: 160px;
+    background: rgba(5, 12, 8, 0.9);
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    border-radius: 14px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(18px) saturate(150%);
+    overflow: hidden;
+    z-index: 40;
+}
+
+.nav-profile-menu a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    color: #e6ffed;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-profile-menu a:hover {
+    background: rgba(82, 176, 67, 0.16);
+    color: #d9ffe4;
 }
 
 /* Liquid Glass Login Effect */
@@ -719,6 +969,245 @@ a.glass-link {
 
 a.glass-link:hover {
     color: #a7f3d0;
+}
+
+.friends-search {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.75rem 0.9rem 0.75rem 1rem;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    backdrop-filter: blur(16px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 12px 26px rgba(0, 0, 0, 0.38);
+    min-width: 280px;
+}
+
+.friends-search-input {
+    background: transparent;
+    border: none;
+    color: #e6ffed;
+    outline: none;
+    width: 100%;
+    font-size: 1rem;
+}
+
+.friends-search-input::placeholder {
+    color: rgba(230, 255, 237, 0.78);
+}
+
+.friends-search-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    border: 1px solid rgba(108, 198, 68, 0.4);
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.2), rgba(16, 124, 16, 0.35));
+    color: #e6ffed;
+    display: grid;
+    place-items: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 10px 24px rgba(0, 0, 0, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.friends-search-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 14px 28px rgba(16, 124, 16, 0.45);
+}
+
+.filter-select {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 14px;
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    background: rgba(5, 12, 8, 0.86);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+    min-width: 210px;
+}
+
+.filter-select-input {
+    appearance: none;
+    background: transparent;
+    border: none;
+    color: #e6ffed;
+    padding: 0.8rem 1rem;
+    width: 100%;
+    font-weight: 700;
+    outline: none;
+    cursor: pointer;
+}
+
+.filter-select-input option {
+    color: #0b1c0d;
+}
+
+.filter-chevron {
+    padding-right: 0.85rem;
+    color: #a7f3d0;
+    pointer-events: none;
+}
+
+.friend-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+}
+
+.friend-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.xbox-glass-card {
+    position: relative;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1.5px solid var(--xbox-border);
+    border-radius: 18px;
+    padding: 1.1rem;
+    box-shadow: var(--xbox-shadow);
+    backdrop-filter: blur(16px) saturate(150%);
+    overflow: hidden;
+    color: #e6ffed;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.xbox-glass-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 18% 18%, rgba(82, 176, 67, 0.16), transparent 48%);
+    opacity: 0.8;
+    pointer-events: none;
+}
+
+.friend-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: rgba(230, 255, 237, 0.78);
+    flex-wrap: wrap;
+}
+
+.friend-status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #7fe391, #52b043);
+    box-shadow: 0 0 12px rgba(82, 176, 67, 0.7);
+}
+
+.friend-card-body {
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: flex-start;
+}
+
+.friend-avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 2px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 12px 26px rgba(0, 0, 0, 0.35);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.friend-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.friend-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.friend-gamertag {
+    font-size: 1.25rem;
+    font-weight: 800;
+    line-height: 1.2;
+    word-break: break-word;
+}
+
+.friend-presence {
+    color: rgba(230, 255, 237, 0.7);
+    font-size: 0.95rem;
+    line-height: 1.3;
+    word-break: break-word;
+}
+
+.friend-gamerscore {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(82, 176, 67, 0.14);
+    border: 1px solid var(--xbox-border);
+    border-radius: 12px;
+    padding: 0.5rem 0.75rem;
+    font-weight: 700;
+    color: #d9ffe4;
+    width: fit-content;
+    flex-wrap: wrap;
+}
+
+.friend-gs-icon {
+    width: 18px;
+    height: 18px;
+}
+
+.friends-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    justify-content: center;
+    margin-top: 0.5rem;
+    align-items: center;
+}
+
+.pagination-btn {
+    min-width: 44px;
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    background: rgba(255, 255, 255, 0.08);
+    color: #e6ffed;
+    font-weight: 700;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.pagination-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(82, 176, 67, 0.16);
+}
+
+.pagination-btn.active {
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.2), rgba(16, 124, 16, 0.35));
+    box-shadow: 0 12px 24px rgba(16, 124, 16, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.pagination-btn.disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.pagination-separator {
+    color: rgba(230, 255, 237, 0.75);
+    padding: 0 0.1rem;
+    font-weight: 700;
 }
 
 .glass-card {

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,8 +1,8 @@
-        <footer class="bg-gray-800 text-white py-4 mt-auto">
-            <div class="text-center">
+        <footer class="xbox-footer">
+            <div class="xbox-footer-content">
                 <p>&copy; 2025 Xbox. Todos os direitos reservados.</p>
             </div>
         </footer>
-        </body>
+    </body>
 
-        </html>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -10,4 +10,4 @@
         <link rel="icon" type="image/png" href="../img/logo2.png"/>
         <title>Xbox</title>
     </head>
-    <body class="bg-gray-100 flex flex-col min-h-screen">
+    <body class="xbox-body">

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -125,31 +125,61 @@
             </div>
         </div>
 
-        <div class="flex items-center space-x-4">
+        <div class="flex items-center space-x-4 ml-4 lg:ml-6">
             <form action="search.php" method="GET" class="nav-search">
                 <i class="fas fa-search text-green-200"></i>
                 <input type="text" name="gamertag_search" placeholder="Buscar Gamertag" class="nav-search-input" required>
                 <button type="submit" class="nav-search-button">Buscar</button>
             </form>
-            <button class="focus:outline-none nav-profile" id="user-menu-button">
-                <div class="nav-profile-ring"></div>
-                <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
-                <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
-            </button>
+            <div class="relative">
+                <button class="focus:outline-none nav-profile" id="user-menu-button">
+                    <div class="nav-profile-ring"></div>
+                    <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
+                    <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
+                    <i class="fas fa-chevron-down text-xs"></i>
+                </button>
+                <div id="user-menu" class="nav-profile-menu hidden">
+                    <a href="../pages/logout.php">
+                        <i class="fas fa-sign-out-alt"></i> Sair
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
 </nav>
 <script>
-    document.getElementById('dropdown-amigos-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-amigos-menu').classList.toggle('hidden');
+    const dropdowns = [
+        { button: 'dropdown-amigos-btn', menu: 'dropdown-amigos-menu' },
+        { button: 'dropdown-activity-btn', menu: 'dropdown-activity-menu' },
+        { button: 'dropdown-gamepass-btn', menu: 'dropdown-gamepass-menu' },
+        { button: 'dropdown-loja-btn', menu: 'dropdown-loja-menu' },
+        { button: 'user-menu-button', menu: 'user-menu' }
+    ];
+
+    dropdowns.forEach(({ button, menu }) => {
+        const btn = document.getElementById(button);
+        const menuEl = document.getElementById(menu);
+
+        if (btn && menuEl) {
+            btn.addEventListener('click', (event) => {
+                event.stopPropagation();
+                const isHidden = menuEl.classList.contains('hidden');
+                closeAllDropdowns();
+                if (isHidden) {
+                    menuEl.classList.remove('hidden');
+                }
+            });
+        }
     });
-    document.getElementById('dropdown-activity-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-activity-menu').classList.toggle('hidden');
-    });
-    document.getElementById('dropdown-gamepass-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-gamepass-menu').classList.toggle('hidden');
-    });
-    document.getElementById('dropdown-loja-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-loja-menu').classList.toggle('hidden');
-    });
+
+    document.addEventListener('click', closeAllDropdowns);
+
+    function closeAllDropdowns() {
+        dropdowns.forEach(({ menu }) => {
+            const el = document.getElementById(menu);
+            if (el && !el.classList.contains('hidden')) {
+                el.classList.add('hidden');
+            }
+        });
+    }
 </script>

--- a/pages/amigos.php
+++ b/pages/amigos.php
@@ -8,111 +8,239 @@
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
+
     $endpoint = "friends";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['people']) && is_array($response['people'])) {
         $friends = $response['people'];
     } else {
         $friends = [];
     }
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4 text-gray-800">Lista de Amigos</h1>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6 space-y-4 md:space-y-0">
-        <div class="flex items-center border border-gray-300 rounded-full px-4 py-2 space-x-2 shadow-lg w-full md:w-1/2 bg-white">
-            <input
-                type="text"
-                id="filterGamertag"
-                placeholder="Buscar por Gamertag..."
-                class="outline-none w-full px-4 bg-white text-gray-700 placeholder-gray-500"
-                style="border: none; box-shadow: none;" />
-            <button id="searchButton" class="outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M12.9 14.32a8 8 0 111.414-1.415l5.387 5.388a1 1 0 01-1.414 1.414l-5.387-5.387zM8 14a6 6 0 100-12 6 6 0 000 12z" clip-rule="evenodd" />
-                </svg>
-            </button>
-        </div>
-        <div class="flex space-x-4">
-            <select id="filterDate" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm w-48">
-                <option value="">Data de Amizade</option>
-                <option value="oldest">Mais Antigo</option>
-                <option value="newest">Mais Recente</option>
-            </select>
-            <select id="filterGamerscore" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm">
-                <option value="">Gamerscore</option>
-                <option value="asc">Ordem Crescente</option>
-                <option value="desc">Ordem Decrescente</option>
-            </select>
-        </div>
-    </div>
-    <?php if (!empty($friends)) : ?>
-        <div id="friendsList" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <?php foreach ($friends as $friend) : ?>
-                <div class="friend-card bg-white text-gray-800 rounded-lg shadow-md overflow-hidden" data-gamertag="<?php echo htmlspecialchars($friend['gamertag']); ?>" data-added="<?php echo (new DateTime($friend['addedDateTimeUtc']))->format('Y-m-d'); ?>" data-gamerscore="<?php echo $friend['gamerScore']; ?>">
-                    <div class="flex">
-                        <?php
-                            $avatar = !empty($friend['displayPicRaw']) ? $friend['displayPicRaw'] : '../img/default_avatar.jpg';
-                            $addedDate = new DateTime($friend['addedDateTimeUtc']);
-                            $formattedDate = $addedDate->format('d/m/Y');
-                        ?>
-                        <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo $friend['displayName']; ?>" class="w-1/3 h-auto object-cover">
-                        <div class="p-4 flex-1">
-                            <h2 class="gamertag text-2xl font-bold mb-2"><?php echo htmlspecialchars($friend['gamertag']); ?></h2>
-                            <p class="added-date text-sm text-gray-500">Amigo desde: <?php echo $formattedDate; ?></p>
-                            <p class="gamerscore text-sm text-gray-500 flex items-center">
-                                Gamerscore: <?php echo number_format($friend['gamerScore'], 0, ',', '.'); ?>
-                                <img src="../img/gs.png" alt="Gamerscore Icon" class="w-4 h-4 ml-2">
-                            </p>
-                            <p class="text-xs text-gray-400 mt-4"><?php echo $friend['presenceText']; ?></p>
-                        </div>
-                    </div>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Lista de Amigos</h1>
+            <p class="xbox-hero-subtitle">Encontre, ordene e navegue pela sua comunidade com cartões em vidro líquido e controles alinhados à navegação.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div class="friends-search">
+                    <i class="fas fa-search text-green-200/80"></i>
+                    <input
+                        type="text"
+                        id="filterGamertag"
+                        placeholder="Buscar por Gamertag..."
+                        class="friends-search-input"
+                    />
+                    <button id="searchButton" class="friends-search-btn" aria-label="Buscar">
+                        <i class="fas fa-arrow-right"></i>
+                    </button>
                 </div>
-            <?php endforeach; ?>
+
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                    <label class="filter-select">
+                        <select id="filterDate" class="filter-select-input">
+                            <option value="">Data de Amizade</option>
+                            <option value="oldest">Mais Antigo</option>
+                            <option value="newest">Mais Recente</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                    <label class="filter-select">
+                        <select id="filterGamerscore" class="filter-select-input">
+                            <option value="">Gamerscore</option>
+                            <option value="asc">Ordem Crescente</option>
+                            <option value="desc">Ordem Decrescente</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                </div>
+            </div>
         </div>
-    <?php else : ?>
-        <p>Você não tem amigos adicionados no momento.</p>
-    <?php endif; ?>
-</div>
+
+        <?php if (!empty($friends)) : ?>
+            <div id="friendsList" class="friend-grid">
+                <?php foreach ($friends as $friend) : ?>
+                    <?php
+                        $avatar = !empty($friend['displayPicRaw']) ? $friend['displayPicRaw'] : '../img/default_avatar.jpg';
+                        $addedDate = new DateTime($friend['addedDateTimeUtc']);
+                        $formattedDate = $addedDate->format('d/m/Y');
+                    ?>
+                    <article class="friend-card xbox-glass-card" data-gamertag="<?php echo htmlspecialchars($friend['gamertag']); ?>" data-added="<?php echo (new DateTime($friend['addedDateTimeUtc']))->format('Y-m-d'); ?>" data-gamerscore="<?php echo $friend['gamerScore']; ?>">
+                        <div class="friend-card-header">
+                            <span class="friend-status-dot"></span>
+                            <span class="friend-added">Amigo desde <?php echo $formattedDate; ?></span>
+                        </div>
+                        <div class="friend-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($friend['displayName']); ?>" />
+                            </div>
+                            <div class="friend-details">
+                                <div class="friend-gamertag"><?php echo htmlspecialchars($friend['gamertag']); ?></div>
+                                <div class="friend-presence"><?php echo $friend['presenceText']; ?></div>
+                                <div class="friend-gamerscore">
+                                    <span>Gamerscore</span>
+                                    <strong><?php echo number_format($friend['gamerScore'], 0, ',', '.'); ?></strong>
+                                    <img src="../img/gs.png" alt="Gamerscore Icon" class="friend-gs-icon">
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="friendsPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Você não tem amigos adicionados no momento.</p>
+        <?php endif; ?>
+    </div>
+</main>
 <script>
-    document.getElementById('filterGamertag').addEventListener('input', filterFriends);
-    document.getElementById('filterDate').addEventListener('change', sortFriends);
-    document.getElementById('filterGamerscore').addEventListener('change', sortFriends);
-    function filterFriends() {
-        let filterGamertag = document.getElementById('filterGamertag').value.toLowerCase();
-        let friendCards = Array.from(document.querySelectorAll('.friend-card'));
-        friendCards.forEach(function(card) {
-            let gamertag = card.getAttribute('data-gamertag').toLowerCase();
-            if (gamertag.includes(filterGamertag)) {
-                card.style.display = '';
-            } else {
-                card.style.display = 'none';
-            }
+    const searchInput = document.getElementById('filterGamertag');
+    const searchButton = document.getElementById('searchButton');
+    const filterDate = document.getElementById('filterDate');
+    const filterGamerscore = document.getElementById('filterGamerscore');
+    const friendsList = document.getElementById('friendsList');
+    const paginationContainer = document.getElementById('friendsPagination');
+    const friendCards = friendsList ? Array.from(friendsList.querySelectorAll('.friend-card')) : [];
+    const PAGE_SIZE = 12;
+    let currentPage = 1;
+
+    function applyFilters() {
+        const gamertagTerm = searchInput.value.toLowerCase();
+        return friendCards.filter((card) => {
+            const gamertag = card.getAttribute('data-gamertag').toLowerCase();
+            return gamertag.includes(gamertagTerm);
         });
     }
-    function sortFriends() {
-        let filterDate = document.getElementById('filterDate').value;
-        let filterGamerscore = document.getElementById('filterGamerscore').value;
-        let friendCards = Array.from(document.querySelectorAll('.friend-card'));
-        if (filterDate !== "") {
-            friendCards.sort(function(a, b) {
-                let dateA = new Date(a.getAttribute('data-added'));
-                let dateB = new Date(b.getAttribute('data-added'));
-                return (filterDate === "newest") ? dateB - dateA : dateA - dateB;
+
+    function applySorting(list) {
+        const dateValue = filterDate.value;
+        const gamerscoreValue = filterGamerscore.value;
+        const sorted = [...list];
+
+        if (dateValue) {
+            sorted.sort((a, b) => {
+                const dateA = new Date(a.getAttribute('data-added'));
+                const dateB = new Date(b.getAttribute('data-added'));
+                return dateValue === 'newest' ? dateB - dateA : dateA - dateB;
             });
         }
-        if (filterGamerscore !== "") {
-            friendCards.sort(function(a, b) {
-                let scoreA = parseInt(a.getAttribute('data-gamerscore'));
-                let scoreB = parseInt(b.getAttribute('data-gamerscore'));
-                return (filterGamerscore === "asc") ? scoreA - scoreB : scoreB - scoreA;
+
+        if (gamerscoreValue) {
+            sorted.sort((a, b) => {
+                const scoreA = parseInt(a.getAttribute('data-gamerscore'), 10);
+                const scoreB = parseInt(b.getAttribute('data-gamerscore'), 10);
+                return gamerscoreValue === 'asc' ? scoreA - scoreB : scoreB - scoreA;
             });
         }
-        let friendsList = document.getElementById('friendsList');
-        friendCards.forEach(function(card) {
-            friendsList.appendChild(card); // Move o card para o fim para reordenar
+
+        return sorted;
+    }
+
+    function renderPagination(totalPages) {
+        paginationContainer.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    currentPage = page;
+                    updateFriends();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            paginationContainer.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, currentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = currentPage > 1;
+        const hasNext = currentPage < totalPages;
+
+        paginationContainer.appendChild(
+            createButton('Anterior', currentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            paginationContainer.appendChild(createButton(page, page, { isActive: page === currentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        paginationContainer.appendChild(
+            createButton('Próximo', currentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateFriends() {
+        if (!friendsList) return;
+
+        const filtered = applyFilters();
+        const sorted = applySorting(filtered);
+        const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+        currentPage = Math.min(currentPage, totalPages);
+
+        friendCards.forEach((card) => {
+            card.style.display = 'none';
         });
+
+        const start = (currentPage - 1) * PAGE_SIZE;
+        const visibleCards = sorted.slice(start, start + PAGE_SIZE);
+        visibleCards.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderPagination(totalPages);
+    }
+
+    if (friendsList) {
+        searchInput.addEventListener('input', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        searchButton.addEventListener('click', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        filterDate.addEventListener('change', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        filterGamerscore.addEventListener('change', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        updateFriends();
     }
 </script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/bloqueados.php
+++ b/pages/bloqueados.php
@@ -8,37 +8,191 @@
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
+
     $endpoint = "friends/blocked";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['users']) && is_array($response['users'])) {
         $blockedFriends = $response['users'];
     } else {
         $blockedFriends = [];
     }
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Amigos Bloqueados</h1>
-    <?php if (!empty($blockedFriends)) : ?>
-        <ul>
-            <?php foreach ($blockedFriends as $blockedFriend) : ?>
-                <li class="mb-4">
-                    <div class="flex items-center space-x-4">
-                        <?php
-                            $avatar = !empty($blockedFriend['displayPicRaw']) ? $blockedFriend['displayPicRaw'] : '../img/default_avatar.jpg';
-                        ?>
-                        <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo $blockedFriend['gamertag']; ?>" class="w-16 h-16 rounded-full">
-                        <div>
-                            <p class="text-xl"><?php echo htmlspecialchars($blockedFriend['gamertag']); ?></p>
-                            <p class="text-sm text-gray-400">Status: Bloqueado</p>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Amigos Bloqueados</h1>
+            <p class="xbox-hero-subtitle">Gerencie a lista de bloqueados com o mesmo visual líquido, filtros e paginação que você usa em Amigos.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="filterBlockedGamertag"
+                    placeholder="Buscar por Gamertag..."
+                    class="friends-search-input"
+                />
+                <button id="blockedSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($blockedFriends)) : ?>
+            <div id="blockedList" class="friend-grid">
+                <?php foreach ($blockedFriends as $blockedFriend) : ?>
+                    <?php
+                        $avatar = !empty($blockedFriend['displayPicRaw']) ? $blockedFriend['displayPicRaw'] : '../img/default_avatar.jpg';
+                        $gamertag = isset($blockedFriend['gamertag']) ? $blockedFriend['gamertag'] : ($blockedFriend['displayName'] ?? 'Usuário');
+                        $realName = $blockedFriend['realName'] ?? '';
+                        $bio = $blockedFriend['bio'] ?? '';
+                    ?>
+                    <article
+                        class="friend-card xbox-glass-card"
+                        data-gamertag="<?php echo htmlspecialchars($gamertag); ?>"
+                    >
+                        <div class="friend-card-header">
+                            <span class="friend-status-dot"></span>
+                            <span class="friend-added">Status: Bloqueado</span>
                         </div>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else : ?>
-        <p>Você não tem amigos bloqueados no momento.</p>
-    <?php endif; ?>
-</div>
+                        <div class="friend-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
+                            <div class="friend-details">
+                                <div class="friend-gamertag"><?php echo htmlspecialchars($gamertag); ?></div>
+                                <?php if (!empty($realName)) : ?>
+                                    <div class="friend-presence"><?php echo htmlspecialchars($realName); ?></div>
+                                <?php elseif (!empty($bio)) : ?>
+                                    <div class="friend-presence"><?php echo htmlspecialchars($bio); ?></div>
+                                <?php else : ?>
+                                    <div class="friend-presence">Usuário bloqueado</div>
+                                <?php endif; ?>
+                                <div class="friend-gamerscore">
+                                    <span>Bloqueio</span>
+                                    <strong>Aplicado</strong>
+                                    <i class="fas fa-ban friend-gs-icon" aria-hidden="true"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="blockedPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Você não tem amigos bloqueados no momento.</p>
+        <?php endif; ?>
+    </div>
+</main>
+<script>
+    const blockedSearchInput = document.getElementById('filterBlockedGamertag');
+    const blockedSearchButton = document.getElementById('blockedSearchButton');
+    const blockedList = document.getElementById('blockedList');
+    const blockedPagination = document.getElementById('blockedPagination');
+    const blockedCards = blockedList ? Array.from(blockedList.querySelectorAll('.friend-card')) : [];
+    const BLOCKED_PAGE_SIZE = 12;
+    let blockedCurrentPage = 1;
+
+    function applyBlockedFilters() {
+        const gamertagTerm = blockedSearchInput.value.toLowerCase();
+        return blockedCards.filter((card) => {
+            const gamertag = card.getAttribute('data-gamertag').toLowerCase();
+            return gamertag.includes(gamertagTerm);
+        });
+    }
+
+    function renderBlockedPagination(totalPages) {
+        blockedPagination.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    blockedCurrentPage = page;
+                    updateBlocked();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            blockedPagination.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, blockedCurrentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = blockedCurrentPage > 1;
+        const hasNext = blockedCurrentPage < totalPages;
+
+        blockedPagination.appendChild(
+            createButton('Anterior', blockedCurrentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            blockedPagination.appendChild(createButton(page, page, { isActive: page === blockedCurrentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        blockedPagination.appendChild(
+            createButton('Próximo', blockedCurrentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateBlocked() {
+        if (!blockedList) return;
+
+        const filtered = applyBlockedFilters();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / BLOCKED_PAGE_SIZE));
+        blockedCurrentPage = Math.min(blockedCurrentPage, totalPages);
+
+        blockedCards.forEach((card) => {
+            card.style.display = 'none';
+        });
+
+        const start = (blockedCurrentPage - 1) * BLOCKED_PAGE_SIZE;
+        const visibleCards = filtered.slice(start, start + BLOCKED_PAGE_SIZE);
+        visibleCards.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderBlockedPagination(totalPages);
+    }
+
+    if (blockedList) {
+        blockedSearchInput.addEventListener('input', () => {
+            blockedCurrentPage = 1;
+            updateBlocked();
+        });
+
+        blockedSearchButton.addEventListener('click', () => {
+            blockedCurrentPage = 1;
+            updateBlocked();
+        });
+
+        updateBlocked();
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -6,84 +6,110 @@
     $endpoint = "account";
     $response = openXBLRequest($endpoint);
     $profileUsers = (is_array($response) && isset($response['profileUsers'][0])) ? $response['profileUsers'][0] : null;
+
     $gamertag = null;
-    if ($profileUsers && isset($profileUsers['settings']) && is_array($profileUsers['settings'])) {
-        foreach ($profileUsers['settings'] as $setting) {
-            if (isset($setting['id']) && $setting['id'] === 'Gamertag') {
-                $gamertag = $setting['value'] ?? null;
-                break;
+    $settings = $profileUsers['settings'] ?? [];
+    $gamerpic = '../img/default_avatar.jpg';
+    $gamerscoreDisplay = '-';
+    $showGamerscoreIcon = false;
+    $accountTier = '-';
+    $reputation = '-';
+    $bio = '-';
+
+    if ($profileUsers && is_array($settings)) {
+        foreach ($settings as $setting) {
+            $id = $setting['id'] ?? null;
+            $value = $setting['value'] ?? null;
+
+            if ($id === 'Gamertag') {
+                $gamertag = $value;
+            }
+
+            if ($id === 'GameDisplayPicRaw') {
+                $gamerpic = $value;
+            }
+
+            if ($id === 'Gamerscore' && is_numeric($value)) {
+                $gamerscoreDisplay = $value >= 1000 ? number_format($value, 0, '', '.') : $value;
+                $showGamerscoreIcon = true;
+            }
+
+            if ($id === 'AccountTier') {
+                $accountTier = $value ?: '-';
+            }
+
+            if ($id === 'XboxOneRep') {
+                $reputation = $value ?: '-';
+            }
+
+            if ($id === 'Bio') {
+                $bio = $value ?: '-';
             }
         }
     }
 ?>
-<div class="container mx-auto mt-10 flex justify-center">
-    <div class="bg-white/30 backdrop-blur-lg p-8 rounded-lg shadow-lg border border-white/20 max-w-lg text-center">
-        <h1 class="text-4xl font-bold mb-4 text-black">Bem-vindo, <span class="text-green-500"><?php echo htmlspecialchars($gamertag); ?></span>!</h1>
-        <ul class="text-left text-black space-y-3">
-            <li><span class="text-green-500 font-bold">Gamerscore:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'Gamerscore') {
-                            $gamerscore = $setting['value'] ?? null;
-                            if (is_numeric($gamerscore)) {
-                                if ($gamerscore >= 1000) {
-                                    echo number_format($gamerscore, 0, '', '.') . ' ';
-                                } else {
-                                    echo $gamerscore . ' ';
-                                }
-                                echo '<img src="../img/gs.png" alt="Gamerscore Icon" class="inline w-5 h-5">';
-                            } else {
-                                echo '-';
-                            }
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Conta:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'AccountTier') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Reputação:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'XboxOneRep') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Bio:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'Bio') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-        </ul>
+<main class="xbox-content">
+    <div class="xbox-page">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Painel</span>
+            <h1 class="xbox-hero-title">Bem-vindo, <span class="text-green-400"><?php echo htmlspecialchars($gamertag); ?></span>!</h1>
+            <p class="xbox-hero-subtitle">Um resumo líquido e iluminado do seu perfil para manter a identidade visual alinhada com a página de login.</p>
+        </section>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="xbox-panel">
+                <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+                    <h2>
+                        <span class="xbox-icon"><i class="fas fa-id-card"></i></span>
+                        Identidade Xbox
+                    </h2>
+                    <span class="xbox-pill"><i class="fas fa-check"></i> Perfil ativo</span>
+                </div>
+
+                <ul class="xbox-stat-list">
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-medal text-green-400"></i> Gamerscore</span>
+                        <span class="xbox-stat-value">
+                            <?php echo htmlspecialchars($gamerscoreDisplay); ?>
+                            <?php if ($showGamerscoreIcon): ?>
+                                <img src="../img/gs.png" alt="Gamerscore Icon" class="inline w-5 h-5">
+                            <?php endif; ?>
+                        </span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-shield-alt text-green-400"></i> Conta</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($accountTier); ?></span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-thumbs-up text-green-400"></i> Reputação</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($reputation); ?></span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-quote-left text-green-400"></i> Bio</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($bio); ?></span>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="xbox-panel flex flex-col gap-4">
+                <div class="flex items-center gap-4 flex-wrap">
+                    <div class="xbox-icon">
+                        <i class="fas fa-user-circle"></i>
+                    </div>
+                    <div>
+                        <h2 class="mb-1">Seu perfil</h2>
+                        <p class="xbox-hero-subtitle text-sm">Detalhes rápidos em um cartão translúcido para manter a experiência consistente.</p>
+                    </div>
+                </div>
+                <div class="flex items-center gap-4 flex-wrap">
+                    <img src="<?php echo htmlspecialchars($gamerpic); ?>" alt="Avatar" class="xbox-avatar">
+                    <div class="space-y-2">
+                        <span class="xbox-pill"><i class="fas fa-user"></i> <?php echo htmlspecialchars($gamertag ?? 'Jogador'); ?></span>
+                        <div class="text-sm text-green-100/80">Personalize seu perfil e conquiste mais com o novo visual.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-</div>
-<br>
+</main>
 <?php include('../includes/footer.php'); ?>

--- a/pages/recentes.php
+++ b/pages/recentes.php
@@ -4,55 +4,195 @@
     include('../includes/navbar.php');
     require '../config/db.php';
     require_once '../config/api.php';
+
     if (!isset($_SESSION['user_id'])) {
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
+
     $endpoint = "recent-players";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['people']) && is_array($response['people'])) {
         $recentPlayers = $response['people'];
     } else {
         $recentPlayers = [];
     }
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Jogadores Recentes</h1>
-    <?php if (!empty($recentPlayers)) : ?>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <?php foreach ($recentPlayers as $player) : ?>
-                <div class="bg-gray-800 text-white shadow-lg rounded-lg overflow-hidden flex">
-                    <div class="w-1/3 bg-gray-700 flex items-center justify-center">
-                        <?php
-                            $avatar = !empty($player['displayPicRaw']) ? $player['displayPicRaw'] : '../img/default_avatar.jpg';
-                        ?>
-                        <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($player['gamertag']); ?>" class="w-full h-full object-cover">
-                    </div>
-                    <div class="w-2/3 p-4 flex flex-col justify-between">
-                        <div>
-                            <h2 class="text-lg font-bold"><?php echo htmlspecialchars($player['gamertag']); ?></h2>
-                            <p class="text-sm text-gray-400 mt-1">Último jogo: <?php echo htmlspecialchars($player['recentPlayer']['titles'][0]['titleName']); ?></p>
-                            <p class="text-sm text-gray-400">Último encontro:
-                                <?php
-                                    $lastPlayed = isset($player['recentPlayer']['titles'][0]['lastPlayedWithDateTime']) ? date('d/m/Y', strtotime($player['recentPlayer']['titles'][0]['lastPlayedWithDateTime'])) : 'Data não disponível';
-                                    echo $lastPlayed;
-                                ?>
-                            </p>
-                        </div>
-                        <div class="mt-2">
-                            <p class="text-sm text-green-400 flex items-center">
-                                Gamerscore: <?php echo number_format($player['gamerScore'], 0, ',', '.'); ?>
-                                <img src="../img/gs.png" alt="Gamerscore Icon" class="inline-block ml-2 w-5 h-5">
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            <?php endforeach; ?>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Jogadores Recentes</h1>
+            <p class="xbox-hero-subtitle">
+                Revise quem jogou com você recentemente com o mesmo visual líquido e controles de busca usados em Amigos e Bloqueados.
+            </p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="filterRecentGamertag"
+                    placeholder="Buscar por Gamertag..."
+                    class="friends-search-input"
+                />
+                <button id="recentSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
         </div>
-    <?php else : ?>
-        <p>Você não jogou com outros jogadores recentemente.</p>
-    <?php endif; ?>
-</div>
+
+        <?php if (!empty($recentPlayers)) : ?>
+            <div id="recentList" class="friend-grid">
+                <?php foreach ($recentPlayers as $player) : ?>
+                    <?php
+                        $avatar = !empty($player['displayPicRaw']) ? $player['displayPicRaw'] : '../img/default_avatar.jpg';
+                        $gamertag = $player['gamertag'] ?? ($player['displayName'] ?? 'Usuário');
+                        $recentTitle = $player['recentPlayer']['titles'][0]['titleName'] ?? 'Jogo recente não informado';
+                        $lastPlayedRaw = $player['recentPlayer']['titles'][0]['lastPlayedWithDateTime'] ?? null;
+                        $lastPlayed = $lastPlayedRaw ? date('d/m/Y', strtotime($lastPlayedRaw)) : 'Data não disponível';
+                        $gamerscore = isset($player['gamerScore']) ? number_format($player['gamerScore'], 0, ',', '.') : '0';
+                    ?>
+                    <article
+                        class="friend-card xbox-glass-card"
+                        data-gamertag="<?php echo htmlspecialchars($gamertag); ?>"
+                    >
+                        <div class="friend-card-header">
+                            <span class="friend-status-dot"></span>
+                            <span class="friend-added">Jogou recentemente</span>
+                        </div>
+                        <div class="friend-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
+                            <div class="friend-details">
+                                <div class="friend-gamertag"><?php echo htmlspecialchars($gamertag); ?></div>
+                                <div class="friend-presence">Último jogo: <?php echo htmlspecialchars($recentTitle); ?></div>
+                                <div class="friend-presence">Último encontro: <?php echo htmlspecialchars($lastPlayed); ?></div>
+                                <div class="friend-gamerscore">
+                                    <span>Gamerscore</span>
+                                    <strong><?php echo $gamerscore; ?></strong>
+                                    <img src="../img/gs.png" alt="Gamerscore Icon" class="friend-gs-icon" />
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="recentPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Você não jogou com outros jogadores recentemente.</p>
+        <?php endif; ?>
+    </div>
+</main>
+<script>
+    const recentSearchInput = document.getElementById('filterRecentGamertag');
+    const recentSearchButton = document.getElementById('recentSearchButton');
+    const recentList = document.getElementById('recentList');
+    const recentPagination = document.getElementById('recentPagination');
+    const recentCards = recentList ? Array.from(recentList.querySelectorAll('.friend-card')) : [];
+    const RECENT_PAGE_SIZE = 12;
+    let recentCurrentPage = 1;
+
+    function applyRecentFilters() {
+        const gamertagTerm = recentSearchInput.value.toLowerCase();
+        return recentCards.filter((card) => {
+            const gamertag = card.getAttribute('data-gamertag').toLowerCase();
+            return gamertag.includes(gamertagTerm);
+        });
+    }
+
+    function renderRecentPagination(totalPages) {
+        recentPagination.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    recentCurrentPage = page;
+                    updateRecent();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            recentPagination.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, recentCurrentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = recentCurrentPage > 1;
+        const hasNext = recentCurrentPage < totalPages;
+
+        recentPagination.appendChild(
+            createButton('Anterior', recentCurrentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            recentPagination.appendChild(createButton(page, page, { isActive: page === recentCurrentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        recentPagination.appendChild(
+            createButton('Próximo', recentCurrentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateRecent() {
+        if (!recentList) return;
+
+        const filtered = applyRecentFilters();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / RECENT_PAGE_SIZE));
+        recentCurrentPage = Math.min(recentCurrentPage, totalPages);
+
+        recentCards.forEach((card) => {
+            card.style.display = 'none';
+        });
+
+        const start = (recentCurrentPage - 1) * RECENT_PAGE_SIZE;
+        const visibleCards = filtered.slice(start, start + RECENT_PAGE_SIZE);
+        visibleCards.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderRecentPagination(totalPages);
+    }
+
+    if (recentList) {
+        recentSearchInput.addEventListener('input', () => {
+            recentCurrentPage = 1;
+            updateRecent();
+        });
+
+        recentSearchButton.addEventListener('click', () => {
+            recentCurrentPage = 1;
+            updateRecent();
+        });
+
+        updateRecent();
+    }
+</script>
 <?php include('../includes/footer.php'); ?>


### PR DESCRIPTION
## Summary
- restyle the blocked friends page with the Xbox hero, search bar, and liquid glass card layout to match the friends experience
- add search filtering and five-wide pagination windows showing twelve blocked users per page
- mirror the same Xbox-styled hero, glass cards, search, and 12-per-page pagination on the Recentes list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ba26d99c832693b5f9d91f36d389)