### PR TITLE
Restyle EA Play, XCloud touch, and PC Game Pass pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,222 @@ html, body {
     height: 100%;
     margin: 0;
 }
+
+:root {
+    --xbox-green: #52b043;
+    --xbox-green-strong: #107c10;
+    --xbox-surface: rgba(255, 255, 255, 0.08);
+    --xbox-border: rgba(82, 176, 67, 0.35);
+    --xbox-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.xbox-body {
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(82, 176, 67, 0.2), transparent 35%),
+        radial-gradient(circle at 80% 0%, rgba(16, 124, 16, 0.25), transparent 30%),
+        linear-gradient(135deg, #050f08 0%, #0b1c0d 40%, #071407 100%);
+    color: #e6ffed;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    overflow-x: hidden;
+}
+
+.xbox-body::before,
+.xbox-body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.xbox-body::before {
+    background:
+        radial-gradient(circle at 15% 75%, rgba(82, 176, 67, 0.25), transparent 35%),
+        radial-gradient(circle at 85% 30%, rgba(108, 198, 68, 0.22), transparent 38%),
+        radial-gradient(circle at 60% 80%, rgba(16, 124, 16, 0.18), transparent 42%);
+    filter: blur(40px);
+    opacity: 0.8;
+}
+
+.xbox-body::after {
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: 140px 140px;
+    opacity: 0.18;
+}
+
+.xbox-body > * {
+    position: relative;
+    z-index: 1;
+}
+
+.xbox-content {
+    flex: 1 0 auto;
+    padding: 2.5rem 1.25rem 3rem;
+}
+
+.xbox-page {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.xbox-hero {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.xbox-hero-eyebrow {
+    color: rgba(230, 255, 237, 0.8);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    font-size: 0.85rem;
+}
+
+.xbox-hero-title {
+    font-size: clamp(2.1rem, 3vw, 2.75rem);
+    font-weight: 800;
+    line-height: 1.1;
+    text-shadow: 0 6px 24px rgba(82, 176, 67, 0.35);
+}
+
+.xbox-hero-subtitle {
+    color: rgba(230, 255, 237, 0.78);
+    max-width: 720px;
+    font-size: 1rem;
+}
+
+.xbox-panel {
+    position: relative;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1.5px solid var(--xbox-border);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: var(--xbox-shadow);
+    backdrop-filter: blur(18px) saturate(150%);
+    overflow: hidden;
+}
+
+.xbox-panel::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(82, 176, 67, 0.12), transparent 55%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.xbox-panel h2 {
+    font-size: 1.35rem;
+    font-weight: 800;
+    color: #e6ffed;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.xbox-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(82, 176, 67, 0.15);
+    color: #d9ffe4;
+    padding: 0.45rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid var(--xbox-border);
+    font-weight: 700;
+    font-size: 0.95rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.xbox-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.25), rgba(16, 124, 16, 0.35));
+    border: 1px solid var(--xbox-border);
+    color: #e6ffed;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+
+.xbox-stat-list {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.9rem;
+    color: rgba(230, 255, 237, 0.9);
+}
+
+.xbox-stat-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.9rem 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(82, 176, 67, 0.22);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.xbox-stat-label {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-weight: 700;
+}
+
+.xbox-stat-value {
+    font-weight: 800;
+    color: #7fe391;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.xbox-avatar {
+    width: 88px;
+    height: 88px;
+    border-radius: 18px;
+    object-fit: cover;
+    border: 2px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.35);
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.xbox-footer {
+    position: relative;
+    margin-top: auto;
+    padding: 1.5rem 1rem;
+    background: rgba(5, 12, 8, 0.9);
+    border-top: 1px solid var(--xbox-border);
+    color: #e6ffed;
+    box-shadow: 0 -12px 32px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+
+.xbox-footer::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 10%, rgba(82, 176, 67, 0.25), transparent 50%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.xbox-footer .xbox-footer-content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+}
 #container {
     min-height: 100%;
     display: flex;
@@ -11,8 +227,8 @@ html, body {
     flex: 1;
 }
 footer {
-    background-color: #1a202c;
-    color: white;
+    background: transparent;
+    color: inherit;
     text-align: center;
     padding: 10px 0;
     position: relative;
@@ -29,7 +245,7 @@ footer {
     backdrop-filter: blur(22px) saturate(160%);
     background: linear-gradient(115deg, rgba(10, 24, 10, 0.72) 0%, rgba(12, 43, 15, 0.82) 45%, rgba(16, 124, 16, 0.65) 100%);
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    overflow: hidden;
+    overflow: visible;
 }
 
 .nav-glass-overlay {
@@ -146,8 +362,8 @@ footer {
 .nav-search {
     display: inline-flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.6rem 0.75rem;
+    gap: 0.55rem;
+    padding: 0.5rem 0.65rem;
     background: rgba(255, 255, 255, 0.08);
     border-radius: 14px;
     border: 1px solid rgba(108, 198, 68, 0.4);
@@ -160,7 +376,8 @@ footer {
     border: none;
     color: #e6ffed;
     outline: none;
-    min-width: 180px;
+    min-width: 150px;
+    font-size: 0.95rem;
 }
 
 .nav-search-input::placeholder {
@@ -171,7 +388,7 @@ footer {
     background: linear-gradient(135deg, #52b043 0%, #107c10 100%);
     color: white;
     font-weight: 700;
-    padding: 0.5rem 0.85rem;
+    padding: 0.45rem 0.75rem;
     border-radius: 12px;
     border: 1px solid rgba(82, 176, 67, 0.6);
     box-shadow: 0 8px 20px rgba(16, 124, 16, 0.35);
@@ -219,6 +436,39 @@ footer {
 .nav-profile-name {
     font-weight: 700;
     text-shadow: 0 4px 14px rgba(82, 176, 67, 0.4);
+    max-width: 140px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.nav-profile-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.5rem);
+    min-width: 160px;
+    background: rgba(5, 12, 8, 0.9);
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    border-radius: 14px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(18px) saturate(150%);
+    overflow: hidden;
+    z-index: 40;
+}
+
+.nav-profile-menu a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    color: #e6ffed;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-profile-menu a:hover {
+    background: rgba(82, 176, 67, 0.16);
+    color: #d9ffe4;
 }
 
 /* Liquid Glass Login Effect */
@@ -719,6 +969,475 @@ a.glass-link {
 
 a.glass-link:hover {
     color: #a7f3d0;
+}
+
+.friends-search {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.75rem 0.9rem 0.75rem 1rem;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    border: 1px solid rgba(82, 176, 67, 0.4);
+    backdrop-filter: blur(16px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 12px 26px rgba(0, 0, 0, 0.38);
+    min-width: 280px;
+}
+
+.friends-search-input {
+    background: transparent;
+    border: none;
+    color: #e6ffed;
+    outline: none;
+    width: 100%;
+    font-size: 1rem;
+}
+
+.friends-search-input::placeholder {
+    color: rgba(230, 255, 237, 0.78);
+}
+
+.friends-search-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    border: 1px solid rgba(108, 198, 68, 0.4);
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.2), rgba(16, 124, 16, 0.35));
+    color: #e6ffed;
+    display: grid;
+    place-items: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 10px 24px rgba(0, 0, 0, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.friends-search-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 14px 28px rgba(16, 124, 16, 0.45);
+}
+
+.filter-select {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 14px;
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    background: rgba(5, 12, 8, 0.86);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+    min-width: 210px;
+}
+
+.filter-select-input {
+    appearance: none;
+    background: transparent;
+    border: none;
+    color: #e6ffed;
+    padding: 0.8rem 1rem;
+    width: 100%;
+    font-weight: 700;
+    outline: none;
+    cursor: pointer;
+}
+
+.filter-select-input option {
+    color: #0b1c0d;
+}
+
+.filter-chevron {
+    padding-right: 0.85rem;
+    color: #a7f3d0;
+    pointer-events: none;
+}
+
+.friend-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+}
+
+.friend-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.xbox-glass-card {
+    position: relative;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1.5px solid var(--xbox-border);
+    border-radius: 18px;
+    padding: 1.1rem;
+    box-shadow: var(--xbox-shadow);
+    backdrop-filter: blur(16px) saturate(150%);
+    overflow: hidden;
+    color: #e6ffed;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.xbox-glass-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 18% 18%, rgba(82, 176, 67, 0.16), transparent 48%);
+    opacity: 0.8;
+    pointer-events: none;
+}
+
+.friend-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: rgba(230, 255, 237, 0.78);
+    flex-wrap: wrap;
+}
+
+.friend-status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #7fe391, #52b043);
+    box-shadow: 0 0 12px rgba(82, 176, 67, 0.7);
+}
+
+.friend-card-body {
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: flex-start;
+}
+
+.friend-avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 2px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 12px 26px rgba(0, 0, 0, 0.35);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.friend-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.friend-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.friend-gamertag {
+    font-size: 1.25rem;
+    font-weight: 800;
+    line-height: 1.2;
+    word-break: break-word;
+}
+
+.friend-presence {
+    color: rgba(230, 255, 237, 0.7);
+    font-size: 0.95rem;
+    line-height: 1.3;
+    word-break: break-word;
+}
+
+.activity-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.activity-date {
+    font-size: 0.9rem;
+    color: rgba(230, 255, 237, 0.7);
+}
+
+.activity-card-body {
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: flex-start;
+}
+
+.activity-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.activity-author {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.activity-description {
+    font-weight: 800;
+    font-size: 1rem;
+    color: #e6ffed;
+    line-height: 1.4;
+    word-break: break-word;
+}
+
+.activity-text {
+    color: rgba(230, 255, 237, 0.78);
+    line-height: 1.45;
+    word-break: break-word;
+}
+
+.game-card {
+    height: 100%;
+}
+
+.game-card-body {
+    display: grid;
+    grid-template-columns: 120px minmax(0, 1fr);
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.game-cover {
+    width: 120px;
+    height: 120px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 2px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 14px 28px rgba(0, 0, 0, 0.4);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.game-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.game-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    min-width: 0;
+}
+
+.game-title {
+    font-size: 1.3rem;
+    font-weight: 800;
+    line-height: 1.25;
+    word-break: break-word;
+}
+
+.game-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.game-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 12px;
+    background: rgba(82, 176, 67, 0.14);
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    color: #d9ffe4;
+    font-size: 0.9rem;
+    line-height: 1.2;
+}
+
+.game-description {
+    color: rgba(230, 255, 237, 0.78);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    max-height: 4.8em;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+}
+
+.game-price {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 800;
+    color: #7fe391;
+}
+
+.activity-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    color: rgba(230, 255, 237, 0.72);
+    font-weight: 700;
+}
+
+.achievement-card .activity-card-body {
+    grid-template-columns: 140px minmax(0, 1fr);
+    align-items: stretch;
+    gap: 1.1rem;
+}
+
+.achievement-body {
+    align-items: stretch;
+}
+
+.achievement-cover {
+    width: 100%;
+    height: 100%;
+    max-height: 210px;
+    border-radius: 14px;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.15);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.achievement-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.achievement-details {
+    gap: 0.75rem;
+}
+
+.achievement-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    align-items: center;
+}
+
+.achievement-platforms {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    align-items: center;
+    color: rgba(230, 255, 237, 0.78);
+}
+
+.achievement-platforms .text-label {
+    font-weight: 800;
+}
+
+.platform-icons img {
+    width: 22px;
+    height: 22px;
+    object-fit: contain;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.35));
+}
+
+.achievement-progress-bar {
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    overflow: hidden;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.achievement-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(82, 176, 67, 0.9), rgba(16, 124, 16, 0.9));
+    box-shadow: 0 10px 18px rgba(16, 124, 16, 0.35);
+}
+
+.activity-like {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.activity-media {
+    margin-top: 0.85rem;
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid var(--xbox-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 18px 38px rgba(0, 0, 0, 0.5);
+    background: linear-gradient(145deg, rgba(18, 35, 26, 0.55), rgba(12, 24, 19, 0.45));
+}
+
+.activity-media img {
+    width: 100%;
+    display: block;
+    object-fit: cover;
+    max-height: 420px;
+}
+
+.friend-gamerscore {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(82, 176, 67, 0.14);
+    border: 1px solid var(--xbox-border);
+    border-radius: 12px;
+    padding: 0.5rem 0.75rem;
+    font-weight: 700;
+    color: #d9ffe4;
+    width: fit-content;
+    flex-wrap: wrap;
+}
+
+.friend-gs-icon {
+    width: 18px;
+    height: 18px;
+}
+
+.friends-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    justify-content: center;
+    margin-top: 0.5rem;
+    align-items: center;
+}
+
+.pagination-btn {
+    min-width: 44px;
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(82, 176, 67, 0.35);
+    background: rgba(255, 255, 255, 0.08);
+    color: #e6ffed;
+    font-weight: 700;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.pagination-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(82, 176, 67, 0.16);
+}
+
+.pagination-btn.active {
+    background: linear-gradient(135deg, rgba(82, 176, 67, 0.2), rgba(16, 124, 16, 0.35));
+    box-shadow: 0 12px 24px rgba(16, 124, 16, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.pagination-btn.disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.pagination-separator {
+    color: rgba(230, 255, 237, 0.75);
+    padding: 0 0.1rem;
+    font-weight: 700;
 }
 
 .glass-card {

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,8 +1,8 @@
-        <footer class="bg-gray-800 text-white py-4 mt-auto">
-            <div class="text-center">
+        <footer class="xbox-footer">
+            <div class="xbox-footer-content">
                 <p>&copy; 2025 Xbox. Todos os direitos reservados.</p>
             </div>
         </footer>
-        </body>
+    </body>
 
-        </html>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -10,4 +10,4 @@
         <link rel="icon" type="image/png" href="../img/logo2.png"/>
         <title>Xbox</title>
     </head>
-    <body class="bg-gray-100 flex flex-col min-h-screen">
+    <body class="xbox-body">

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -125,31 +125,61 @@
             </div>
         </div>
 
-        <div class="flex items-center space-x-4">
+        <div class="flex items-center space-x-4 ml-4 lg:ml-6">
             <form action="search.php" method="GET" class="nav-search">
                 <i class="fas fa-search text-green-200"></i>
                 <input type="text" name="gamertag_search" placeholder="Buscar Gamertag" class="nav-search-input" required>
                 <button type="submit" class="nav-search-button">Buscar</button>
             </form>
-            <button class="focus:outline-none nav-profile" id="user-menu-button">
-                <div class="nav-profile-ring"></div>
-                <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
-                <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
-            </button>
+            <div class="relative">
+                <button class="focus:outline-none nav-profile" id="user-menu-button">
+                    <div class="nav-profile-ring"></div>
+                    <img src="<?php echo $gamerpic; ?>" alt="Profile" class="nav-profile-img">
+                    <span class="nav-profile-name"><?php echo htmlspecialchars($gamertag); ?></span>
+                    <i class="fas fa-chevron-down text-xs"></i>
+                </button>
+                <div id="user-menu" class="nav-profile-menu hidden">
+                    <a href="../pages/logout.php">
+                        <i class="fas fa-sign-out-alt"></i> Sair
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
 </nav>
 <script>
-    document.getElementById('dropdown-amigos-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-amigos-menu').classList.toggle('hidden');
+    const dropdowns = [
+        { button: 'dropdown-amigos-btn', menu: 'dropdown-amigos-menu' },
+        { button: 'dropdown-activity-btn', menu: 'dropdown-activity-menu' },
+        { button: 'dropdown-gamepass-btn', menu: 'dropdown-gamepass-menu' },
+        { button: 'dropdown-loja-btn', menu: 'dropdown-loja-menu' },
+        { button: 'user-menu-button', menu: 'user-menu' }
+    ];
+
+    dropdowns.forEach(({ button, menu }) => {
+        const btn = document.getElementById(button);
+        const menuEl = document.getElementById(menu);
+
+        if (btn && menuEl) {
+            btn.addEventListener('click', (event) => {
+                event.stopPropagation();
+                const isHidden = menuEl.classList.contains('hidden');
+                closeAllDropdowns();
+                if (isHidden) {
+                    menuEl.classList.remove('hidden');
+                }
+            });
+        }
     });
-    document.getElementById('dropdown-activity-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-activity-menu').classList.toggle('hidden');
-    });
-    document.getElementById('dropdown-gamepass-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-gamepass-menu').classList.toggle('hidden');
-    });
-    document.getElementById('dropdown-loja-btn').addEventListener('click', function() {
-        document.getElementById('dropdown-loja-menu').classList.toggle('hidden');
-    });
+
+    document.addEventListener('click', closeAllDropdowns);
+
+    function closeAllDropdowns() {
+        dropdowns.forEach(({ menu }) => {
+            const el = document.getElementById(menu);
+            if (el && !el.classList.contains('hidden')) {
+                el.classList.add('hidden');
+            }
+        });
+    }
 </script>

--- a/pages/amigos.php
+++ b/pages/amigos.php
@@ -8,111 +8,239 @@
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
+
     $endpoint = "friends";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['people']) && is_array($response['people'])) {
         $friends = $response['people'];
     } else {
         $friends = [];
     }
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4 text-gray-800">Lista de Amigos</h1>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6 space-y-4 md:space-y-0">
-        <div class="flex items-center border border-gray-300 rounded-full px-4 py-2 space-x-2 shadow-lg w-full md:w-1/2 bg-white">
-            <input
-                type="text"
-                id="filterGamertag"
-                placeholder="Buscar por Gamertag..."
-                class="outline-none w-full px-4 bg-white text-gray-700 placeholder-gray-500"
-                style="border: none; box-shadow: none;" />
-            <button id="searchButton" class="outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M12.9 14.32a8 8 0 111.414-1.415l5.387 5.388a1 1 0 01-1.414 1.414l-5.387-5.387zM8 14a6 6 0 100-12 6 6 0 000 12z" clip-rule="evenodd" />
-                </svg>
-            </button>
-        </div>
-        <div class="flex space-x-4">
-            <select id="filterDate" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm w-48">
-                <option value="">Data de Amizade</option>
-                <option value="oldest">Mais Antigo</option>
-                <option value="newest">Mais Recente</option>
-            </select>
-            <select id="filterGamerscore" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm">
-                <option value="">Gamerscore</option>
-                <option value="asc">Ordem Crescente</option>
-                <option value="desc">Ordem Decrescente</option>
-            </select>
-        </div>
-    </div>
-    <?php if (!empty($friends)) : ?>
-        <div id="friendsList" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <?php foreach ($friends as $friend) : ?>
-                <div class="friend-card bg-white text-gray-800 rounded-lg shadow-md overflow-hidden" data-gamertag="<?php echo htmlspecialchars($friend['gamertag']); ?>" data-added="<?php echo (new DateTime($friend['addedDateTimeUtc']))->format('Y-m-d'); ?>" data-gamerscore="<?php echo $friend['gamerScore']; ?>">
-                    <div class="flex">
-                        <?php
-                            $avatar = !empty($friend['displayPicRaw']) ? $friend['displayPicRaw'] : '../img/default_avatar.jpg';
-                            $addedDate = new DateTime($friend['addedDateTimeUtc']);
-                            $formattedDate = $addedDate->format('d/m/Y');
-                        ?>
-                        <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo $friend['displayName']; ?>" class="w-1/3 h-auto object-cover">
-                        <div class="p-4 flex-1">
-                            <h2 class="gamertag text-2xl font-bold mb-2"><?php echo htmlspecialchars($friend['gamertag']); ?></h2>
-                            <p class="added-date text-sm text-gray-500">Amigo desde: <?php echo $formattedDate; ?></p>
-                            <p class="gamerscore text-sm text-gray-500 flex items-center">
-                                Gamerscore: <?php echo number_format($friend['gamerScore'], 0, ',', '.'); ?>
-                                <img src="../img/gs.png" alt="Gamerscore Icon" class="w-4 h-4 ml-2">
-                            </p>
-                            <p class="text-xs text-gray-400 mt-4"><?php echo $friend['presenceText']; ?></p>
-                        </div>
-                    </div>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Lista de Amigos</h1>
+            <p class="xbox-hero-subtitle">Encontre, ordene e navegue pela sua comunidade com cartões em vidro líquido e controles alinhados à navegação.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div class="friends-search">
+                    <i class="fas fa-search text-green-200/80"></i>
+                    <input
+                        type="text"
+                        id="filterGamertag"
+                        placeholder="Buscar por Gamertag..."
+                        class="friends-search-input"
+                    />
+                    <button id="searchButton" class="friends-search-btn" aria-label="Buscar">
+                        <i class="fas fa-arrow-right"></i>
+                    </button>
                 </div>
-            <?php endforeach; ?>
+
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                    <label class="filter-select">
+                        <select id="filterDate" class="filter-select-input">
+                            <option value="">Data de Amizade</option>
+                            <option value="oldest">Mais Antigo</option>
+                            <option value="newest">Mais Recente</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                    <label class="filter-select">
+                        <select id="filterGamerscore" class="filter-select-input">
+                            <option value="">Gamerscore</option>
+                            <option value="asc">Ordem Crescente</option>
+                            <option value="desc">Ordem Decrescente</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                </div>
+            </div>
         </div>
-    <?php else : ?>
-        <p>Você não tem amigos adicionados no momento.</p>
-    <?php endif; ?>
-</div>
+
+        <?php if (!empty($friends)) : ?>
+            <div id="friendsList" class="friend-grid">
+                <?php foreach ($friends as $friend) : ?>
+                    <?php
+                        $avatar = !empty($friend['displayPicRaw']) ? $friend['displayPicRaw'] : '../img/default_avatar.jpg';
+                        $addedDate = new DateTime($friend['addedDateTimeUtc']);
+                        $formattedDate = $addedDate->format('d/m/Y');
+                    ?>
+                    <article class="friend-card xbox-glass-card" data-gamertag="<?php echo htmlspecialchars($friend['gamertag']); ?>" data-added="<?php echo (new DateTime($friend['addedDateTimeUtc']))->format('Y-m-d'); ?>" data-gamerscore="<?php echo $friend['gamerScore']; ?>">
+                        <div class="friend-card-header">
+                            <span class="friend-status-dot"></span>
+                            <span class="friend-added">Amigo desde <?php echo $formattedDate; ?></span>
+                        </div>
+                        <div class="friend-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($friend['displayName']); ?>" />
+                            </div>
+                            <div class="friend-details">
+                                <div class="friend-gamertag"><?php echo htmlspecialchars($friend['gamertag']); ?></div>
+                                <div class="friend-presence"><?php echo $friend['presenceText']; ?></div>
+                                <div class="friend-gamerscore">
+                                    <span>Gamerscore</span>
+                                    <strong><?php echo number_format($friend['gamerScore'], 0, ',', '.'); ?></strong>
+                                    <img src="../img/gs.png" alt="Gamerscore Icon" class="friend-gs-icon">
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="friendsPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Você não tem amigos adicionados no momento.</p>
+        <?php endif; ?>
+    </div>
+</main>
 <script>
-    document.getElementById('filterGamertag').addEventListener('input', filterFriends);
-    document.getElementById('filterDate').addEventListener('change', sortFriends);
-    document.getElementById('filterGamerscore').addEventListener('change', sortFriends);
-    function filterFriends() {
-        let filterGamertag = document.getElementById('filterGamertag').value.toLowerCase();
-        let friendCards = Array.from(document.querySelectorAll('.friend-card'));
-        friendCards.forEach(function(card) {
-            let gamertag = card.getAttribute('data-gamertag').toLowerCase();
-            if (gamertag.includes(filterGamertag)) {
-                card.style.display = '';
-            } else {
-                card.style.display = 'none';
-            }
+    const searchInput = document.getElementById('filterGamertag');
+    const searchButton = document.getElementById('searchButton');
+    const filterDate = document.getElementById('filterDate');
+    const filterGamerscore = document.getElementById('filterGamerscore');
+    const friendsList = document.getElementById('friendsList');
+    const paginationContainer = document.getElementById('friendsPagination');
+    const friendCards = friendsList ? Array.from(friendsList.querySelectorAll('.friend-card')) : [];
+    const PAGE_SIZE = 12;
+    let currentPage = 1;
+
+    function applyFilters() {
+        const gamertagTerm = searchInput.value.toLowerCase();
+        return friendCards.filter((card) => {
+            const gamertag = card.getAttribute('data-gamertag').toLowerCase();
+            return gamertag.includes(gamertagTerm);
         });
     }
-    function sortFriends() {
-        let filterDate = document.getElementById('filterDate').value;
-        let filterGamerscore = document.getElementById('filterGamerscore').value;
-        let friendCards = Array.from(document.querySelectorAll('.friend-card'));
-        if (filterDate !== "") {
-            friendCards.sort(function(a, b) {
-                let dateA = new Date(a.getAttribute('data-added'));
-                let dateB = new Date(b.getAttribute('data-added'));
-                return (filterDate === "newest") ? dateB - dateA : dateA - dateB;
+
+    function applySorting(list) {
+        const dateValue = filterDate.value;
+        const gamerscoreValue = filterGamerscore.value;
+        const sorted = [...list];
+
+        if (dateValue) {
+            sorted.sort((a, b) => {
+                const dateA = new Date(a.getAttribute('data-added'));
+                const dateB = new Date(b.getAttribute('data-added'));
+                return dateValue === 'newest' ? dateB - dateA : dateA - dateB;
             });
         }
-        if (filterGamerscore !== "") {
-            friendCards.sort(function(a, b) {
-                let scoreA = parseInt(a.getAttribute('data-gamerscore'));
-                let scoreB = parseInt(b.getAttribute('data-gamerscore'));
-                return (filterGamerscore === "asc") ? scoreA - scoreB : scoreB - scoreA;
+
+        if (gamerscoreValue) {
+            sorted.sort((a, b) => {
+                const scoreA = parseInt(a.getAttribute('data-gamerscore'), 10);
+                const scoreB = parseInt(b.getAttribute('data-gamerscore'), 10);
+                return gamerscoreValue === 'asc' ? scoreA - scoreB : scoreB - scoreA;
             });
         }
-        let friendsList = document.getElementById('friendsList');
-        friendCards.forEach(function(card) {
-            friendsList.appendChild(card); // Move o card para o fim para reordenar
+
+        return sorted;
+    }
+
+    function renderPagination(totalPages) {
+        paginationContainer.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    currentPage = page;
+                    updateFriends();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            paginationContainer.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, currentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = currentPage > 1;
+        const hasNext = currentPage < totalPages;
+
+        paginationContainer.appendChild(
+            createButton('Anterior', currentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            paginationContainer.appendChild(createButton(page, page, { isActive: page === currentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        paginationContainer.appendChild(
+            createButton('Próximo', currentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateFriends() {
+        if (!friendsList) return;
+
+        const filtered = applyFilters();
+        const sorted = applySorting(filtered);
+        const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+        currentPage = Math.min(currentPage, totalPages);
+
+        friendCards.forEach((card) => {
+            card.style.display = 'none';
         });
+
+        const start = (currentPage - 1) * PAGE_SIZE;
+        const visibleCards = sorted.slice(start, start + PAGE_SIZE);
+        visibleCards.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderPagination(totalPages);
+    }
+
+    if (friendsList) {
+        searchInput.addEventListener('input', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        searchButton.addEventListener('click', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        filterDate.addEventListener('change', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        filterGamerscore.addEventListener('change', () => {
+            currentPage = 1;
+            updateFriends();
+        });
+
+        updateFriends();
     }
 </script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/bloqueados.php
+++ b/pages/bloqueados.php
@@ -8,37 +8,191 @@
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
+
     $endpoint = "friends/blocked";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['users']) && is_array($response['users'])) {
         $blockedFriends = $response['users'];
     } else {
         $blockedFriends = [];
     }
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Amigos Bloqueados</h1>
-    <?php if (!empty($blockedFriends)) : ?>
-        <ul>
-            <?php foreach ($blockedFriends as $blockedFriend) : ?>
-                <li class="mb-4">
-                    <div class="flex items-center space-x-4">
-                        <?php
-                            $avatar = !empty($blockedFriend['displayPicRaw']) ? $blockedFriend['displayPicRaw'] : '../img/default_avatar.jpg';
-                        ?>
-                        <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo $blockedFriend['gamertag']; ?>" class="w-16 h-16 rounded-full">
-                        <div>
-                            <p class="text-xl"><?php echo htmlspecialchars($blockedFriend['gamertag']); ?></p>
-                            <p class="text-sm text-gray-400">Status: Bloqueado</p>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Amigos Bloqueados</h1>
+            <p class="xbox-hero-subtitle">Gerencie a lista de bloqueados com o mesmo visual líquido, filtros e paginação que você usa em Amigos.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="filterBlockedGamertag"
+                    placeholder="Buscar por Gamertag..."
+                    class="friends-search-input"
+                />
+                <button id="blockedSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($blockedFriends)) : ?>
+            <div id="blockedList" class="friend-grid">
+                <?php foreach ($blockedFriends as $blockedFriend) : ?>
+                    <?php
+                        $avatar = !empty($blockedFriend['displayPicRaw']) ? $blockedFriend['displayPicRaw'] : '../img/default_avatar.jpg';
+                        $gamertag = isset($blockedFriend['gamertag']) ? $blockedFriend['gamertag'] : ($blockedFriend['displayName'] ?? 'Usuário');
+                        $realName = $blockedFriend['realName'] ?? '';
+                        $bio = $blockedFriend['bio'] ?? '';
+                    ?>
+                    <article
+                        class="friend-card xbox-glass-card"
+                        data-gamertag="<?php echo htmlspecialchars($gamertag); ?>"
+                    >
+                        <div class="friend-card-header">
+                            <span class="friend-status-dot"></span>
+                            <span class="friend-added">Status: Bloqueado</span>
                         </div>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else : ?>
-        <p>Você não tem amigos bloqueados no momento.</p>
-    <?php endif; ?>
-</div>
+                        <div class="friend-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
+                            <div class="friend-details">
+                                <div class="friend-gamertag"><?php echo htmlspecialchars($gamertag); ?></div>
+                                <?php if (!empty($realName)) : ?>
+                                    <div class="friend-presence"><?php echo htmlspecialchars($realName); ?></div>
+                                <?php elseif (!empty($bio)) : ?>
+                                    <div class="friend-presence"><?php echo htmlspecialchars($bio); ?></div>
+                                <?php else : ?>
+                                    <div class="friend-presence">Usuário bloqueado</div>
+                                <?php endif; ?>
+                                <div class="friend-gamerscore">
+                                    <span>Bloqueio</span>
+                                    <strong>Aplicado</strong>
+                                    <i class="fas fa-ban friend-gs-icon" aria-hidden="true"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="blockedPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Você não tem amigos bloqueados no momento.</p>
+        <?php endif; ?>
+    </div>
+</main>
+<script>
+    const blockedSearchInput = document.getElementById('filterBlockedGamertag');
+    const blockedSearchButton = document.getElementById('blockedSearchButton');
+    const blockedList = document.getElementById('blockedList');
+    const blockedPagination = document.getElementById('blockedPagination');
+    const blockedCards = blockedList ? Array.from(blockedList.querySelectorAll('.friend-card')) : [];
+    const BLOCKED_PAGE_SIZE = 12;
+    let blockedCurrentPage = 1;
+
+    function applyBlockedFilters() {
+        const gamertagTerm = blockedSearchInput.value.toLowerCase();
+        return blockedCards.filter((card) => {
+            const gamertag = card.getAttribute('data-gamertag').toLowerCase();
+            return gamertag.includes(gamertagTerm);
+        });
+    }
+
+    function renderBlockedPagination(totalPages) {
+        blockedPagination.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    blockedCurrentPage = page;
+                    updateBlocked();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            blockedPagination.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, blockedCurrentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = blockedCurrentPage > 1;
+        const hasNext = blockedCurrentPage < totalPages;
+
+        blockedPagination.appendChild(
+            createButton('Anterior', blockedCurrentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            blockedPagination.appendChild(createButton(page, page, { isActive: page === blockedCurrentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        blockedPagination.appendChild(
+            createButton('Próximo', blockedCurrentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateBlocked() {
+        if (!blockedList) return;
+
+        const filtered = applyBlockedFilters();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / BLOCKED_PAGE_SIZE));
+        blockedCurrentPage = Math.min(blockedCurrentPage, totalPages);
+
+        blockedCards.forEach((card) => {
+            card.style.display = 'none';
+        });
+
+        const start = (blockedCurrentPage - 1) * BLOCKED_PAGE_SIZE;
+        const visibleCards = filtered.slice(start, start + BLOCKED_PAGE_SIZE);
+        visibleCards.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderBlockedPagination(totalPages);
+    }
+
+    if (blockedList) {
+        blockedSearchInput.addEventListener('input', () => {
+            blockedCurrentPage = 1;
+            updateBlocked();
+        });
+
+        blockedSearchButton.addEventListener('click', () => {
+            blockedCurrentPage = 1;
+            updateBlocked();
+        });
+
+        updateBlocked();
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/conquistas.php
+++ b/pages/conquistas.php
@@ -4,41 +4,45 @@
     include('../includes/navbar.php');
     require '../config/db.php';
     require_once '../config/api.php';
+
     if (!isset($_SESSION['user_id'])) {
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
-    // Obter informações da conta para XUID (usa endpoint account que retorna dados da conta autenticada)
+
     $endpoint = "achievements";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['titles']) && is_array($response['titles'])) {
         $games = $response['titles'];
     } else {
         $games = [];
-        // Mensagem amigável se não houver dados disponíveis
         $error_message = "Não foi possível carregar suas conquistas. Verifique se a chave da API está configurada corretamente no arquivo .env";
     }
-    function getDeviceIcon($deviceType) {
+
+    $items_per_page = 12;
+
+    function getDeviceIcon($deviceType)
+    {
         switch ($deviceType) {
             case 'XboxSeries':
-                return '<img src="../img/xboxseries.png" alt="Xbox Series" width="62,5" height="62,5">';
+                return '<img src="../img/xboxseries.png" alt="Xbox Series" width="24" height="24">';
             case 'PC':
-                return '<img src="../img/windows.png" alt="PC" width="62,5" height="62,5">';
-            case 'XboxOne':
-                return '<img src="../img/xboxone.png" alt="Xbox One" width="62,5" height="62,5">';
             case 'Win32':
-                return '<img src="../img/windows.png" alt="PC" width="62,5" height="62,5">';
+                return '<img src="../img/windows.png" alt="PC" width="24" height="24">';
+            case 'XboxOne':
+                return '<img src="../img/xboxone.png" alt="Xbox One" width="24" height="24">';
             case 'Mobile':
-                return '<img src="../img/windowsphone.webp" alt="Windows Phone" width="62,5" height="62,5">';
+                return '<img src="../img/windowsphone.webp" alt="Windows Phone" width="24" height="24">';
             case 'Xbox360':
-                return '<img src="../img/xbox360.png" alt="Xbox 360" width="62,5" height="62,5">';
+                return '<img src="../img/xbox360.png" alt="Xbox 360" width="24" height="24">';
             default:
-                return $deviceType;
+                return htmlspecialchars($deviceType);
         }
     }
-    function getBoxArt($game) {
+
+    function getBoxArt($game)
+    {
         if (isset($game['images'])) {
             foreach ($game['images'] as $image) {
                 if ($image['type'] === 'BoxArt') {
@@ -46,179 +50,298 @@
                 }
             }
         }
+
         return '../img/default_game.jpg';
     }
-    $items_per_page = 12;
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl text-center mb-6">Conquistas</h1>
-    
-    <?php if (isset($error_message)): ?>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <strong class="font-bold">Atenção!</strong>
-            <span class="block sm:inline"><?php echo htmlspecialchars($error_message); ?></span>
-        </div>
-    <?php endif; ?>
-    
-    <?php if (empty($games) && !isset($error_message)): ?>
-        <div class="bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">Você ainda não possui jogos com conquistas registradas.</span>
-        </div>
-    <?php else: ?>
-    
-    <div class="flex flex-col items-center space-y-4">
-        <div class="relative w-full max-w-lg">
-            <input
-                type="text"
-                id="searchInput"
-                placeholder="Buscar por Nome..."
-                class="w-full px-6 py-3 text-gray-700 bg-white rounded-full shadow-lg outline-none focus:ring-2 focus:ring-blue-300" />
-            <button class="absolute right-4 top-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a7 7 0 107 7 7 7 0 00-7-7zM21 21l-4.35-4.35" />
-                </svg>
-            </button>
-        </div>
-        <div class="flex flex-wrap justify-center space-x-4">
-            <select id="filterName" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm w-48">
-                <option value="">Nome</option>
-                <option value="asc">A-Z</option>
-                <option value="desc">Z-A</option>
-            </select>
-            <select id="filterGamerscore" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm w-48">
-                <option value="">Gamerscore</option>
-                <option value="asc">Do menor para o maior</option>
-                <option value="desc">Do maior para o menor</option>
-            </select>
-            <select id="filterLastPlayed" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm w-56">
-                <option value="">Jogado pela Última Vez</option>
-                <option value="recent">Mais Recente</option>
-                <option value="oldest">Mais Antigo</option>
-            </select>
-            <select id="filterPlatform" class="border p-2 rounded-full bg-white text-gray-700 shadow-sm w-48">
-                <option value="">Plataformas</option>
-                <option value="Mobile">Mobile (Windows Phone)</option>
-                <option value="PC">PC (Windows Store)</option>
-                <option value="Win32">PC (Outros)</option>
-                <option value="Xbox360">Xbox 360</option>
-                <option value="XboxOne">Xbox One</option>
-                <option value="XboxSeries">Xbox Series</option>
-            </select>
-        </div>
-    </div>
-    <div id="gameList" class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-        <!-- Jogos carregados via JavaScript -->
-    </div>
-    <div class="mt-4 flex justify-center space-x-4">
-        <button id="prevPage" class="bg-gray-800 text-white px-4 py-2 rounded">Anterior</button>
-        <button id="nextPage" class="bg-gray-800 text-white px-4 py-2 rounded">Próxima</button>
-    </div>
-</div>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Jogos</span>
+            <h1 class="xbox-hero-title">Conquistas</h1>
+            <p class="xbox-hero-subtitle">
+                Explore seus títulos com filtros e paginação no estilo Xbox, mantendo a identidade de vidro líquido.
+            </p>
+        </section>
 
-<?php endif; ?>
+        <div class="xbox-panel space-y-4">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div class="friends-search">
+                    <i class="fas fa-search text-green-200/80"></i>
+                    <input
+                        type="text"
+                        id="achievementSearch"
+                        placeholder="Buscar por Nome..."
+                        class="friends-search-input"
+                    />
+                    <button id="achievementSearchButton" class="friends-search-btn" aria-label="Buscar">
+                        <i class="fas fa-arrow-right"></i>
+                    </button>
+                </div>
 
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                    <label class="filter-select">
+                        <select id="filterName" class="filter-select-input">
+                            <option value="">Nome</option>
+                            <option value="asc">A-Z</option>
+                            <option value="desc">Z-A</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                    <label class="filter-select">
+                        <select id="filterGamerscore" class="filter-select-input">
+                            <option value="">Gamerscore</option>
+                            <option value="asc">Do menor para o maior</option>
+                            <option value="desc">Do maior para o menor</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                    <label class="filter-select">
+                        <select id="filterLastPlayed" class="filter-select-input">
+                            <option value="">Jogado pela Última Vez</option>
+                            <option value="recent">Mais Recente</option>
+                            <option value="oldest">Mais Antigo</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                    <label class="filter-select">
+                        <select id="filterPlatform" class="filter-select-input">
+                            <option value="">Plataformas</option>
+                            <option value="Mobile">Mobile (Windows Phone)</option>
+                            <option value="PC">PC (Windows Store)</option>
+                            <option value="Win32">PC (Outros)</option>
+                            <option value="Xbox360">Xbox 360</option>
+                            <option value="XboxOne">Xbox One</option>
+                            <option value="XboxSeries">Xbox Series</option>
+                        </select>
+                        <span class="filter-chevron"><i class="fas fa-chevron-down"></i></span>
+                    </label>
+                </div>
+            </div>
+        </div>
+
+        <?php if (isset($error_message)) : ?>
+            <p class="text-green-50"><?php echo htmlspecialchars($error_message); ?></p>
+        <?php elseif (empty($games)) : ?>
+            <p class="text-green-50">Você ainda não possui jogos com conquistas registradas.</p>
+        <?php else : ?>
+            <div id="achievementsList" class="friend-grid">
+                <?php foreach ($games as $game) : ?>
+                    <?php
+                        $boxArt = getBoxArt($game);
+                        $name = $game['name'] ?? 'Título não disponível';
+                        $devices = $game['devices'] ?? [];
+                        $deviceIcons = !empty($devices)
+                            ? implode(' ', array_map('getDeviceIcon', $devices))
+                            : 'Plataforma não disponível';
+                        $currentGs = $game['achievement']['currentGamerscore'] ?? 0;
+                        $progress = $game['achievement']['progressPercentage'] ?? 0;
+                        $lastPlayedRaw = $game['titleHistory']['lastTimePlayed'] ?? null;
+                        $lastPlayed = $lastPlayedRaw ? date('d/m/Y', strtotime($lastPlayedRaw)) : 'Data não disponível';
+                        $lastPlayedSort = $lastPlayedRaw ? strtotime($lastPlayedRaw) : 0;
+                        $platformsAttr = !empty($devices) ? strtolower(implode(',', $devices)) : '';
+                    ?>
+                    <article
+                        class="friend-card xbox-glass-card achievement-card"
+                        data-name="<?php echo htmlspecialchars(strtolower($name)); ?>"
+                        data-gamerscore="<?php echo $currentGs; ?>"
+                        data-last-played="<?php echo $lastPlayedSort; ?>"
+                        data-platforms="<?php echo htmlspecialchars($platformsAttr); ?>"
+                    >
+                        <div class="activity-card-header">
+                            <div class="friend-card-header">
+                                <span class="friend-status-dot"></span>
+                                <span class="friend-added">Atualizado em <?php echo htmlspecialchars($lastPlayed); ?></span>
+                            </div>
+                            <div class="badge-soft">Progresso: <?php echo $progress; ?>%</div>
+                        </div>
+                        <div class="activity-card-body achievement-body">
+                            <div class="friend-avatar achievement-cover">
+                                <img src="<?php echo htmlspecialchars($boxArt); ?>" alt="Capa de <?php echo htmlspecialchars($name); ?>" />
+                            </div>
+                            <div class="activity-details achievement-details">
+                                <div class="activity-author">
+                                    <div class="friend-gamertag"><?php echo htmlspecialchars($name); ?></div>
+                                    <div class="friend-presence">Jogado pela última vez em <?php echo htmlspecialchars($lastPlayed); ?></div>
+                                </div>
+                                <div class="achievement-meta">
+                                    <div class="friend-gamerscore">
+                                        <span>Gamerscore</span>
+                                        <strong><?php echo number_format($currentGs, 0, ',', '.'); ?></strong>
+                                        <img src="../img/gs.png" alt="Gamerscore Icon" class="friend-gs-icon">
+                                    </div>
+                                    <div class="achievement-platforms">
+                                        <span class="text-label">Plataformas:</span>
+                                        <span class="platform-icons"><?php echo $deviceIcons; ?></span>
+                                    </div>
+                                </div>
+                                <div class="achievement-progress-bar">
+                                    <div class="achievement-progress-fill" style="width: <?php echo min(100, (float)$progress); ?>%"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="achievementsPagination" class="friends-pagination"></div>
+        <?php endif; ?>
+    </div>
+</main>
 <script>
-    const games = <?php echo json_encode($games); ?>;
-    const itemsPerPage = <?php echo $items_per_page; ?>;
+    const achievementSearch = document.getElementById('achievementSearch');
+    const achievementSearchButton = document.getElementById('achievementSearchButton');
+    const filterName = document.getElementById('filterName');
+    const filterGamerscore = document.getElementById('filterGamerscore');
+    const filterLastPlayed = document.getElementById('filterLastPlayed');
+    const filterPlatform = document.getElementById('filterPlatform');
+    const achievementsList = document.getElementById('achievementsList');
+    const paginationContainer = document.getElementById('achievementsPagination');
+    const achievementCards = achievementsList ? Array.from(achievementsList.querySelectorAll('.achievement-card')) : [];
+    const PAGE_SIZE = <?php echo $items_per_page; ?>;
     let currentPage = 1;
-    let filteredGames = games;
-    function renderGames() {
-        const gameList = document.getElementById('gameList');
-        gameList.innerHTML = '';
-        const start = (currentPage - 1) * itemsPerPage;
-        const end = currentPage * itemsPerPage;
-        const gamesToShow = filteredGames.slice(start, end);
-        gamesToShow.forEach(game => {
-            const gameCard = `
-                <div class="bg-gray-800 p-4 rounded-lg shadow-md flex game-card">
-                    <div class="relative w-1/3">
-                        <img src="${game.images && game.images.find(image => image.type === 'BoxArt') ? game.images.find(image => image.type === 'BoxArt').url : '../img/default_game.jpg'}" alt="Imagem do jogo" class="object-cover rounded-l-md h-full">
-                    </div>
-                    <div class="w-2/3 p-4">
-                        <p class="text-xl font-bold text-white game-name">${game.name}</p>
-                        <p class="text-sm text-gray-400 gamerscore">Gamerscore: ${game.achievement.currentGamerscore.toLocaleString()} <img src="../img/gs.png" alt="Gamerscore Icon" class="inline-block w-4 h-4"></p>
-                        <p class="text-sm text-gray-400 progress">Progresso: ${game.achievement.progressPercentage}%</p>
-                        <p class="text-sm text-gray-400 flex items-center space-x-2 platform">Plataformas: ${
-                            game.devices ? game.devices.map(device => getDeviceIcon(device)).join(' ') : 'Plataforma não disponível'
-                        }</p>
-                        <p class="text-sm text-gray-400 last-played">Jogado pela última vez: ${new Date(game.titleHistory.lastTimePlayed).toLocaleDateString()}</p>
-                    </div>
-                </div>`;
-            gameList.innerHTML += gameCard;
+
+    function applyFilters() {
+        const term = achievementSearch.value.toLowerCase();
+        const platform = filterPlatform.value.toLowerCase();
+
+        return achievementCards.filter((card) => {
+            const matchesName = card.getAttribute('data-name').includes(term);
+            const platforms = card.getAttribute('data-platforms');
+            const matchesPlatform = !platform || (platforms && platforms.split(',').includes(platform));
+            return matchesName && matchesPlatform;
         });
-        document.getElementById('prevPage').style.display = currentPage === 1 ? 'none' : 'inline';
-        document.getElementById('nextPage').style.display = currentPage * itemsPerPage >= filteredGames.length ? 'none' : 'inline';
     }
-    function filterGames() {
-        const searchInput = document.getElementById('searchInput').value.toLowerCase();
-        const filterPlatform = document.getElementById('filterPlatform').value;
-        filteredGames = games.filter(game => {
-            const nameMatch = game.name.toLowerCase().includes(searchInput);
-            const platformMatch = filterPlatform === "" || (game.devices && game.devices.includes(filterPlatform));
-            return nameMatch && platformMatch;
+
+    function applySorting(list) {
+        const nameSort = filterName.value;
+        const gsSort = filterGamerscore.value;
+        const lastPlayedSort = filterLastPlayed.value;
+        const sorted = [...list];
+
+        if (nameSort) {
+            sorted.sort((a, b) => {
+                const nameA = a.getAttribute('data-name');
+                const nameB = b.getAttribute('data-name');
+                return nameSort === 'asc' ? nameA.localeCompare(nameB) : nameB.localeCompare(nameA);
+            });
+        }
+
+        if (gsSort) {
+            sorted.sort((a, b) => {
+                const gsA = parseInt(a.getAttribute('data-gamerscore'), 10) || 0;
+                const gsB = parseInt(b.getAttribute('data-gamerscore'), 10) || 0;
+                return gsSort === 'asc' ? gsA - gsB : gsB - gsA;
+            });
+        }
+
+        if (lastPlayedSort) {
+            sorted.sort((a, b) => {
+                const dateA = parseInt(a.getAttribute('data-last-played'), 10) || 0;
+                const dateB = parseInt(b.getAttribute('data-last-played'), 10) || 0;
+                return lastPlayedSort === 'recent' ? dateB - dateA : dateA - dateB;
+            });
+        }
+
+        return sorted;
+    }
+
+    function renderPagination(totalPages) {
+        paginationContainer.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    currentPage = page;
+                    updateAchievements();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            paginationContainer.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, currentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = currentPage > 1;
+        const hasNext = currentPage < totalPages;
+
+        paginationContainer.appendChild(
+            createButton('Anterior', currentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            paginationContainer.appendChild(createButton(page, page, { isActive: page === currentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        paginationContainer.appendChild(
+            createButton('Próximo', currentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateAchievements() {
+        if (!achievementsList) return;
+
+        const filtered = applyFilters();
+        const sorted = applySorting(filtered);
+        const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+        currentPage = Math.min(currentPage, totalPages);
+
+        achievementCards.forEach((card) => {
+            card.style.display = 'none';
         });
-        currentPage = 1;
-        renderGames();
+
+        const start = (currentPage - 1) * PAGE_SIZE;
+        const visible = sorted.slice(start, start + PAGE_SIZE);
+        visible.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderPagination(totalPages);
     }
-    function sortGames() {
-        const filterName = document.getElementById('filterName').value;
-        const filterGamerscore = document.getElementById('filterGamerscore').value;
-        const filterLastPlayed = document.getElementById('filterLastPlayed').value;
-        if (filterName !== "") {
-            filteredGames.sort((a, b) => {
-                return filterName === 'asc' ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name);
+
+    if (achievementsList) {
+        achievementSearch.addEventListener('input', () => {
+            currentPage = 1;
+            updateAchievements();
+        });
+
+        achievementSearchButton.addEventListener('click', () => {
+            currentPage = 1;
+            updateAchievements();
+        });
+
+        [filterName, filterGamerscore, filterLastPlayed, filterPlatform].forEach((select) => {
+            select.addEventListener('change', () => {
+                currentPage = 1;
+                updateAchievements();
             });
-        }
-        if (filterGamerscore !== "") {
-            filteredGames.sort((a, b) => {
-                return filterGamerscore === 'asc' ? a.achievement.currentGamerscore - b.achievement.currentGamerscore : b.achievement.currentGamerscore - a.achievement.currentGamerscore;
-            });
-        }
-        if (filterLastPlayed !== "") {
-            filteredGames.sort((a, b) => {
-                const lastPlayedA = new Date(a.titleHistory.lastTimePlayed);
-                const lastPlayedB = new Date(b.titleHistory.lastTimePlayed);
-                return filterLastPlayed === 'recent' ? lastPlayedB - lastPlayedA : lastPlayedA - lastPlayedB;
-            });
-        }
-        currentPage = 1;
-        renderGames();
+        });
+
+        updateAchievements();
     }
-    document.getElementById('searchInput').addEventListener('input', filterGames);
-    document.getElementById('filterName').addEventListener('change', sortGames);
-    document.getElementById('filterGamerscore').addEventListener('change', sortGames);
-    document.getElementById('filterLastPlayed').addEventListener('change', sortGames);
-    document.getElementById('filterPlatform').addEventListener('change', filterGames);
-    document.getElementById('prevPage').addEventListener('click', () => {
-        if (currentPage > 1) {
-            currentPage--;
-            renderGames();
-        }
-    });
-    document.getElementById('nextPage').addEventListener('click', () => {
-        if (currentPage * itemsPerPage < filteredGames.length) {
-            currentPage++;
-            renderGames();
-        }
-    });
-    function getDeviceIcon(deviceType) {
-        switch (deviceType) {
-            case 'XboxSeries':
-                return '<img src="../img/xboxseries.png" alt="Xbox Series" width="62,5" height="62,5">';
-            case 'PC':
-                return '<img src="../img/windows.png" alt="PC" width="62,5" height="62,5">';
-            case 'XboxOne':
-                return '<img src="../img/xboxone.png" alt="Xbox One" width="62,5" height="62,5">';
-            case 'Win32':
-                return '<img src="../img/windows.png" alt="PC" width="62,5" height="62,5">';
-            case 'Mobile':
-                return '<img src="../img/windowsphone.webp" alt="Windows Phone" width="62,5" height="62,5">';
-            case 'Xbox360':
-                return '<img src="../img/xbox360.png" alt="Xbox 360" width="62,5" height="62,5">';
-            default:
-                return deviceType;
-        }
-    }
-    renderGames();
 </script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -6,84 +6,110 @@
     $endpoint = "account";
     $response = openXBLRequest($endpoint);
     $profileUsers = (is_array($response) && isset($response['profileUsers'][0])) ? $response['profileUsers'][0] : null;
+
     $gamertag = null;
-    if ($profileUsers && isset($profileUsers['settings']) && is_array($profileUsers['settings'])) {
-        foreach ($profileUsers['settings'] as $setting) {
-            if (isset($setting['id']) && $setting['id'] === 'Gamertag') {
-                $gamertag = $setting['value'] ?? null;
-                break;
+    $settings = $profileUsers['settings'] ?? [];
+    $gamerpic = '../img/default_avatar.jpg';
+    $gamerscoreDisplay = '-';
+    $showGamerscoreIcon = false;
+    $accountTier = '-';
+    $reputation = '-';
+    $bio = '-';
+
+    if ($profileUsers && is_array($settings)) {
+        foreach ($settings as $setting) {
+            $id = $setting['id'] ?? null;
+            $value = $setting['value'] ?? null;
+
+            if ($id === 'Gamertag') {
+                $gamertag = $value;
+            }
+
+            if ($id === 'GameDisplayPicRaw') {
+                $gamerpic = $value;
+            }
+
+            if ($id === 'Gamerscore' && is_numeric($value)) {
+                $gamerscoreDisplay = $value >= 1000 ? number_format($value, 0, '', '.') : $value;
+                $showGamerscoreIcon = true;
+            }
+
+            if ($id === 'AccountTier') {
+                $accountTier = $value ?: '-';
+            }
+
+            if ($id === 'XboxOneRep') {
+                $reputation = $value ?: '-';
+            }
+
+            if ($id === 'Bio') {
+                $bio = $value ?: '-';
             }
         }
     }
 ?>
-<div class="container mx-auto mt-10 flex justify-center">
-    <div class="bg-white/30 backdrop-blur-lg p-8 rounded-lg shadow-lg border border-white/20 max-w-lg text-center">
-        <h1 class="text-4xl font-bold mb-4 text-black">Bem-vindo, <span class="text-green-500"><?php echo htmlspecialchars($gamertag); ?></span>!</h1>
-        <ul class="text-left text-black space-y-3">
-            <li><span class="text-green-500 font-bold">Gamerscore:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'Gamerscore') {
-                            $gamerscore = $setting['value'] ?? null;
-                            if (is_numeric($gamerscore)) {
-                                if ($gamerscore >= 1000) {
-                                    echo number_format($gamerscore, 0, '', '.') . ' ';
-                                } else {
-                                    echo $gamerscore . ' ';
-                                }
-                                echo '<img src="../img/gs.png" alt="Gamerscore Icon" class="inline w-5 h-5">';
-                            } else {
-                                echo '-';
-                            }
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Conta:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'AccountTier') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Reputação:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'XboxOneRep') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-            <li><span class="text-green-500 font-bold">Bio:</span>
-                <?php
-                $settings = $profileUsers['settings'] ?? [];
-                if (is_array($settings)) {
-                    foreach ($settings as $setting) {
-                        if (isset($setting['id']) && $setting['id'] === 'Bio') {
-                            echo htmlspecialchars($setting['value'] ?? '-');
-                            break;
-                        }
-                    }
-                }
-                ?>
-            </li>
-        </ul>
+<main class="xbox-content">
+    <div class="xbox-page">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Painel</span>
+            <h1 class="xbox-hero-title">Bem-vindo, <span class="text-green-400"><?php echo htmlspecialchars($gamertag); ?></span>!</h1>
+            <p class="xbox-hero-subtitle">Um resumo líquido e iluminado do seu perfil para manter a identidade visual alinhada com a página de login.</p>
+        </section>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="xbox-panel">
+                <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+                    <h2>
+                        <span class="xbox-icon"><i class="fas fa-id-card"></i></span>
+                        Identidade Xbox
+                    </h2>
+                    <span class="xbox-pill"><i class="fas fa-check"></i> Perfil ativo</span>
+                </div>
+
+                <ul class="xbox-stat-list">
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-medal text-green-400"></i> Gamerscore</span>
+                        <span class="xbox-stat-value">
+                            <?php echo htmlspecialchars($gamerscoreDisplay); ?>
+                            <?php if ($showGamerscoreIcon): ?>
+                                <img src="../img/gs.png" alt="Gamerscore Icon" class="inline w-5 h-5">
+                            <?php endif; ?>
+                        </span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-shield-alt text-green-400"></i> Conta</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($accountTier); ?></span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-thumbs-up text-green-400"></i> Reputação</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($reputation); ?></span>
+                    </li>
+                    <li class="xbox-stat-item">
+                        <span class="xbox-stat-label"><i class="fas fa-quote-left text-green-400"></i> Bio</span>
+                        <span class="xbox-stat-value"><?php echo htmlspecialchars($bio); ?></span>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="xbox-panel flex flex-col gap-4">
+                <div class="flex items-center gap-4 flex-wrap">
+                    <div class="xbox-icon">
+                        <i class="fas fa-user-circle"></i>
+                    </div>
+                    <div>
+                        <h2 class="mb-1">Seu perfil</h2>
+                        <p class="xbox-hero-subtitle text-sm">Detalhes rápidos em um cartão translúcido para manter a experiência consistente.</p>
+                    </div>
+                </div>
+                <div class="flex items-center gap-4 flex-wrap">
+                    <img src="<?php echo htmlspecialchars($gamerpic); ?>" alt="Avatar" class="xbox-avatar">
+                    <div class="space-y-2">
+                        <span class="xbox-pill"><i class="fas fa-user"></i> <?php echo htmlspecialchars($gamertag ?? 'Jogador'); ?></span>
+                        <div class="text-sm text-green-100/80">Personalize seu perfil e conquiste mais com o novo visual.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-</div>
-<br>
+</main>
 <?php include('../includes/footer.php'); ?>

--- a/pages/ea_play.php
+++ b/pages/ea_play.php
@@ -15,7 +15,7 @@
         echo "Nenhum jogo encontrado no banco de dados.";
         exit;
     }
-    $items_per_page = 10;
+    $items_per_page = 12;
     $total_items = count($game_ids);
     $total_pages = ceil($total_items / $items_per_page);
     $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
@@ -27,61 +27,127 @@
     ];
     $response = openXBLPostRequest($endpoint, $body);
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Todos os Jogos do EA Play </h1>
-    <?php if (!empty($response['Products'])) : ?>
-        <ul>
-            <?php foreach ($response['Products'] as $product) : ?>
-                <li class="mb-4">
-                    <div class="flex items-center space-x-4">
-                        <?php
-                            $boxArtImage = null;
-                            if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
-                                foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
-                                    if ($image['ImagePurpose'] === 'BoxArt') {
-                                        $boxArtImage = $image['Uri'];
-                                        break;
-                                    }
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Game Pass</span>
+            <h1 class="xbox-hero-title">Todos os Jogos do EA Play</h1>
+            <p class="xbox-hero-subtitle">Explore a coleção do EA Play com busca temática, cartões em vidro líquido e paginação alinhada ao restante da experiência.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="eaSearch"
+                    placeholder="Buscar por título..."
+                    class="friends-search-input"
+                />
+                <button id="eaSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($response['Products'])) : ?>
+            <div id="eaList" class="friend-grid">
+                <?php foreach ($response['Products'] as $product) : ?>
+                    <?php
+                        $boxArtImage = null;
+                        if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
+                            foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
+                                if ($image['ImagePurpose'] === 'BoxArt') {
+                                    $boxArtImage = $image['Uri'];
+                                    break;
                                 }
                             }
-                        ?>
-                        <?php if ($boxArtImage): ?>
-                            <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Imagem do jogo" class="w-16 h-16 rounded-full">
-                        <?php else: ?>
-                            <img src="../img/placeholder.png" alt="Imagem não disponível" class="w-16 h-16 rounded-full">
-                        <?php endif; ?>
-                        <div>
-                            <p class="text-xl"><?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">
-                                Preço:
-                                <?php
-                                    if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
-                                        echo '$' . number_format($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'], 2);
-                                    } else {
-                                        echo 'Não disponível';
-                                    }
-                                ?>
-                            </p>
-                            <p class="text-sm text-gray-400">Descrição: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Desenvolvedora: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Publisher: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Franquia: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Categoria: <?php echo htmlspecialchars($product['Properties']['Category'] ?? 'Não disponível'); ?></p>
+                        }
+
+                        $title = $product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível';
+                        $description = $product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível';
+                        $developer = $product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida';
+                        $publisher = $product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida';
+                        $franchise = $product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível';
+                        $category = $product['Properties']['Category'] ?? 'Não disponível';
+
+                        $price = 'Não disponível';
+                        if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
+                            $priceValue = $product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'];
+                            $price = '$' . number_format($priceValue, 2);
+                        }
+                    ?>
+                    <article class="friend-card xbox-glass-card game-card" data-title="<?php echo htmlspecialchars(strtolower($title)); ?>">
+                        <div class="game-card-body">
+                            <div class="game-cover">
+                                <?php if ($boxArtImage) : ?>
+                                    <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Capa de <?php echo htmlspecialchars($title); ?>">
+                                <?php else : ?>
+                                    <img src="../img/placeholder.png" alt="Imagem não disponível">
+                                <?php endif; ?>
+                            </div>
+                            <div class="game-details">
+                                <div class="game-title"><?php echo htmlspecialchars($title); ?></div>
+                                <div class="game-meta">
+                                    <span class="game-badge">Desenvolvedora: <?php echo htmlspecialchars($developer); ?></span>
+                                    <span class="game-badge">Publisher: <?php echo htmlspecialchars($publisher); ?></span>
+                                    <span class="game-badge">Franquia: <?php echo htmlspecialchars($franchise); ?></span>
+                                    <span class="game-badge">Categoria: <?php echo htmlspecialchars($category); ?></span>
+                                </div>
+                                <p class="game-description"><?php echo htmlspecialchars($description); ?></p>
+                                <div class="game-price">Preço: <strong><?php echo htmlspecialchars($price); ?></strong></div>
+                            </div>
                         </div>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else : ?>
-        <p>Nenhum detalhe de jogo encontrado.</p>
-    <?php endif; ?>
-    <div class="mt-4">
-        <?php if ($page > 1) : ?>
-            <a href="?page=<?php echo $page - 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Anterior</a>
-        <?php endif; ?>
-        <?php if ($page < $total_pages) : ?>
-            <a href="?page=<?php echo $page + 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Próxima</a>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div class="friends-pagination">
+                <?php
+                    $maxVisible = 5;
+                    $halfWindow = floor($maxVisible / 2);
+                    $startPage = max(1, $page - $halfWindow);
+                    $endPage = min($total_pages, $startPage + $maxVisible - 1);
+
+                    if (($endPage - $startPage + 1) < $maxVisible) {
+                        $startPage = max(1, $endPage - $maxVisible + 1);
+                    }
+
+                    $hasPrev = $page > 1;
+                    $hasNext = $page < $total_pages;
+                ?>
+                <a class="pagination-btn <?php echo $hasPrev ? '' : 'disabled'; ?>" href="<?php echo $hasPrev ? '?page=' . ($page - 1) : 'javascript:void(0);'; ?>">Anterior</a>
+                <span class="pagination-separator">|</span>
+                <?php for ($p = $startPage; $p <= $endPage; $p++) : ?>
+                    <a class="pagination-btn <?php echo $p === $page ? 'active' : ''; ?>" href="?page=<?php echo $p; ?>"><?php echo $p; ?></a>
+                    <?php if ($p < $endPage) : ?>
+                        <span class="pagination-separator">|</span>
+                    <?php endif; ?>
+                <?php endfor; ?>
+                <span class="pagination-separator">|</span>
+                <a class="pagination-btn <?php echo $hasNext ? '' : 'disabled'; ?>" href="<?php echo $hasNext ? '?page=' . ($page + 1) : 'javascript:void(0);'; ?>">Próximo</a>
+            </div>
+        <?php else : ?>
+            <p class="text-green-50">Nenhum detalhe de jogo encontrado.</p>
         <?php endif; ?>
     </div>
-</div>
+</main>
+<script>
+    const eaSearchInput = document.getElementById('eaSearch');
+    const eaSearchButton = document.getElementById('eaSearchButton');
+    const eaList = document.getElementById('eaList');
+    const eaCards = eaList ? Array.from(eaList.querySelectorAll('.game-card')) : [];
+
+    function filterEaGames() {
+        const term = eaSearchInput.value.toLowerCase();
+        eaCards.forEach((card) => {
+            const title = card.getAttribute('data-title') || '';
+            card.style.display = title.includes(term) ? '' : 'none';
+        });
+    }
+
+    if (eaList) {
+        eaSearchInput.addEventListener('input', filterEaGames);
+        eaSearchButton.addEventListener('click', filterEaGames);
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/feed.php
+++ b/pages/feed.php
@@ -3,62 +3,187 @@
     include('../includes/header.php');
     include('../includes/navbar.php');
     require_once '../config/api.php';
+
     $endpoint = "activity/feed";
     $response = openXBLRequest($endpoint);
     $activityItems = $response['activityItems'] ?? [];
-    $items_per_page = 5;
-    $total_items = count($activityItems);
-    $total_pages = ceil($total_items / $items_per_page);
-    $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
-    $offset = ($page - 1) * $items_per_page;
-    $current_page_items = array_slice($activityItems, $offset, $items_per_page);
 ?>
-<div class="container mx-auto mt-10">
-    <h1 class="text-3xl font-bold mb-6 text-center text-green-400">Feed de Atividades</h1>
-    <?php if (!empty($current_page_items)): ?>
-        <div class="grid grid-cols-1 gap-6">
-            <?php foreach ($current_page_items as $item): ?>
-                <div class="bg-gray-800 p-6 rounded-lg shadow-md hover:bg-gray-700 transition duration-200">
-                    <div class="flex items-center mb-4">
-                        <img src="<?php echo $item['authorInfo']['imageUrl']; ?>" alt="Avatar" class="w-16 h-16 rounded-full mr-4">
-                        <div>
-                            <p class="text-lg font-bold text-green-400"><?php echo $item['authorInfo']['modernGamertag']; ?></p>
-                            <p class="text-sm text-gray-400"><?php echo $item['authorInfo']['secondName'] ?? 'Nome não disponível'; ?></p>
-                        </div>
-                    </div>
-                    <div class="bg-gray-900 p-4 rounded-lg">
-                        <p class="text-white mb-2"><strong><?php echo $item['description']; ?></strong></p>
-                        <p class="text-gray-400"><?php echo $item['itemText'] ?? 'Texto não disponível'; ?></p>
-                        <p class="text-gray-500 text-sm mt-1">
-                            Compartilhado em: <?php echo $item['timeline']['timelineName'] ?? 'Timeline não disponível'; ?>
-                        </p>
-                        <div class="flex justify-between items-center mt-2">
-                            <p class="text-gray-500 text-xs">
-                                Publicado em: <?php echo isset($item['date']) ? date('d/m/Y H:i', strtotime($item['date'])) : 'Data não disponível'; ?>
-                            </p>
-                        </div>
-                        <div class="flex justify-between mt-2">
-                            <p class="text-sm text-gray-400">
-                                Comentários: <?php echo isset($item['numComments']) ? $item['numComments'] : 'Sem comentários'; ?>
-                            </p>
-                            <p class="text-sm text-gray-400">
-                                Likes: <?php echo $item['hasLiked'] ? '✔️' : '❌'; ?>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            <?php endforeach; ?>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Feed de Atividades</h1>
+            <p class="xbox-hero-subtitle">
+                Veja capturas, clips e atualizações recentes com cartões de vidro líquido e navegação alinhada ao restante da experiência.
+            </p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="feedSearch"
+                    placeholder="Buscar por Gamertag..."
+                    class="friends-search-input"
+                />
+                <button id="feedSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
         </div>
-        <div class="flex justify-between mt-6">
-            <?php if ($page > 1): ?>
-                <a href="?page=<?php echo $page - 1; ?>" class="bg-gray-700 text-white px-4 py-2 rounded-lg hover:bg-gray-600">Anterior</a>
-            <?php endif; ?>
-            <?php if ($page < $total_pages): ?>
-                <a href="?page=<?php echo $page + 1; ?>" class="bg-gray-700 text-white px-4 py-2 rounded-lg hover:bg-gray-600 ml-auto">Próxima</a>
-            <?php endif; ?>
-        </div>
-    <?php else: ?>
-        <p class="text-gray-400 text-center">Nenhuma atividade disponível no momento.</p>
-    <?php endif; ?>
-</div>
+
+        <?php if (!empty($activityItems)) : ?>
+            <div id="feedList" class="friend-grid">
+                <?php foreach ($activityItems as $item) : ?>
+                    <?php
+                        $author = $item['authorInfo'] ?? [];
+                        $avatar = !empty($author['imageUrl']) ? $author['imageUrl'] : '../img/default_avatar.jpg';
+                        $gamertag = $author['modernGamertag'] ?? 'Gamertag indisponível';
+                        $secondary = $author['secondName'] ?? 'Nome não disponível';
+                        $description = $item['description'] ?? 'Atividade';
+                        $itemText = $item['itemText'] ?? 'Texto não disponível';
+                        $timeline = $item['timeline']['timelineName'] ?? 'Timeline não disponível';
+                        $dateRaw = $item['date'] ?? null;
+                        $formattedDate = $dateRaw ? date('d/m/Y H:i', strtotime($dateRaw)) : 'Data não disponível';
+                        $comments = isset($item['numComments']) ? $item['numComments'] : 'Sem comentários';
+                        $liked = !empty($item['hasLiked']);
+                    ?>
+                    <article class="friend-card xbox-glass-card activity-card" data-gamertag="<?php echo htmlspecialchars(strtolower($gamertag)); ?>">
+                        <div class="activity-card-header">
+                            <div class="friend-card-header">
+                                <span class="friend-status-dot"></span>
+                                <span class="friend-added">Compartilhado em <?php echo htmlspecialchars($timeline); ?></span>
+                            </div>
+                            <span class="activity-date">Publicado em <?php echo $formattedDate; ?></span>
+                        </div>
+                        <div class="activity-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo htmlspecialchars($avatar); ?>" alt="Avatar de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
+                            <div class="activity-details">
+                                <div class="activity-author">
+                                    <div class="friend-gamertag"><?php echo htmlspecialchars($gamertag); ?></div>
+                                    <div class="friend-presence"><?php echo htmlspecialchars($secondary); ?></div>
+                                </div>
+                                <div class="activity-description"><?php echo htmlspecialchars($description); ?></div>
+                                <div class="activity-text"><?php echo htmlspecialchars($itemText); ?></div>
+                                <div class="activity-meta">
+                                    <span>Comentários: <?php echo htmlspecialchars($comments); ?></span>
+                                    <span class="activity-like">Likes: <?php echo $liked ? '✔️' : '❌'; ?></span>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="feedPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Nenhuma atividade disponível no momento.</p>
+        <?php endif; ?>
+    </div>
+</main>
+<script>
+    const feedSearchInput = document.getElementById('feedSearch');
+    const feedSearchButton = document.getElementById('feedSearchButton');
+    const feedList = document.getElementById('feedList');
+    const paginationContainer = document.getElementById('feedPagination');
+    const feedCards = feedList ? Array.from(feedList.querySelectorAll('.activity-card')) : [];
+    const PAGE_SIZE = 12;
+    let currentPage = 1;
+
+    function filterFeed() {
+        const term = feedSearchInput.value.toLowerCase();
+        return feedCards.filter((card) => card.getAttribute('data-gamertag').includes(term));
+    }
+
+    function renderPagination(totalPages) {
+        paginationContainer.innerHTML = '';
+        if (totalPages <= 1) return;
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    currentPage = page;
+                    updateFeed();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            paginationContainer.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, currentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = currentPage > 1;
+        const hasNext = currentPage < totalPages;
+
+        paginationContainer.appendChild(
+            createButton('Anterior', currentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            paginationContainer.appendChild(createButton(page, page, { isActive: page === currentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        paginationContainer.appendChild(
+            createButton('Próximo', currentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateFeed() {
+        if (!feedList) return;
+
+        const filtered = filterFeed();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+        currentPage = Math.min(currentPage, totalPages);
+
+        feedCards.forEach((card) => {
+            card.style.display = 'none';
+        });
+
+        const start = (currentPage - 1) * PAGE_SIZE;
+        const visible = filtered.slice(start, start + PAGE_SIZE);
+        visible.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderPagination(totalPages);
+    }
+
+    if (feedList) {
+        feedSearchInput.addEventListener('input', () => {
+            currentPage = 1;
+            updateFeed();
+        });
+
+        feedSearchButton.addEventListener('click', () => {
+            currentPage = 1;
+            updateFeed();
+        });
+
+        updateFeed();
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/gamepass_pc.php
+++ b/pages/gamepass_pc.php
@@ -15,7 +15,7 @@
         echo "Nenhum jogo encontrado no banco de dados.";
         exit;
     }
-    $items_per_page = 10;
+    $items_per_page = 12;
     $total_items = count($game_ids);
     $total_pages = ceil($total_items / $items_per_page);
     $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
@@ -27,61 +27,127 @@
     ];
     $response = openXBLPostRequest($endpoint, $body);
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Todos os Jogos do PC Game Pass </h1>
-    <?php if (!empty($response['Products'])) : ?>
-        <ul>
-            <?php foreach ($response['Products'] as $product) : ?>
-                <li class="mb-4">
-                    <div class="flex items-center space-x-4">
-                        <?php
-                            $boxArtImage = null;
-                            if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
-                                foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
-                                    if ($image['ImagePurpose'] === 'BoxArt') {
-                                        $boxArtImage = $image['Uri'];
-                                        break;
-                                    }
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Game Pass</span>
+            <h1 class="xbox-hero-title">Todos os Jogos do PC Game Pass</h1>
+            <p class="xbox-hero-subtitle">Navegue pelos jogos do PC Game Pass com busca temática, cartões em vidro líquido e paginação consistente.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="pcSearch"
+                    placeholder="Buscar por título..."
+                    class="friends-search-input"
+                />
+                <button id="pcSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($response['Products'])) : ?>
+            <div id="pcList" class="friend-grid">
+                <?php foreach ($response['Products'] as $product) : ?>
+                    <?php
+                        $boxArtImage = null;
+                        if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
+                            foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
+                                if ($image['ImagePurpose'] === 'BoxArt') {
+                                    $boxArtImage = $image['Uri'];
+                                    break;
                                 }
                             }
-                        ?>
-                        <?php if ($boxArtImage): ?>
-                            <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Imagem do jogo" class="w-16 h-16 rounded-full">
-                        <?php else: ?>
-                            <img src="../img/placeholder.png" alt="Imagem não disponível" class="w-16 h-16 rounded-full">
-                        <?php endif; ?>
-                        <div>
-                            <p class="text-xl"><?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">
-                                Preço:
-                                <?php
-                                    if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
-                                        echo '$' . number_format($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'], 2);
-                                    } else {
-                                        echo 'Não disponível';
-                                    }
-                                ?>
-                            </p>
-                            <p class="text-sm text-gray-400">Descrição: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Desenvolvedora: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Publisher: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Franquia: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Categoria: <?php echo htmlspecialchars($product['Properties']['Category'] ?? 'Não disponível'); ?></p>
+                        }
+
+                        $title = $product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível';
+                        $description = $product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível';
+                        $developer = $product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida';
+                        $publisher = $product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida';
+                        $franchise = $product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível';
+                        $category = $product['Properties']['Category'] ?? 'Não disponível';
+
+                        $price = 'Não disponível';
+                        if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
+                            $priceValue = $product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'];
+                            $price = '$' . number_format($priceValue, 2);
+                        }
+                    ?>
+                    <article class="friend-card xbox-glass-card game-card" data-title="<?php echo htmlspecialchars(strtolower($title)); ?>">
+                        <div class="game-card-body">
+                            <div class="game-cover">
+                                <?php if ($boxArtImage) : ?>
+                                    <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Capa de <?php echo htmlspecialchars($title); ?>">
+                                <?php else : ?>
+                                    <img src="../img/placeholder.png" alt="Imagem não disponível">
+                                <?php endif; ?>
+                            </div>
+                            <div class="game-details">
+                                <div class="game-title"><?php echo htmlspecialchars($title); ?></div>
+                                <div class="game-meta">
+                                    <span class="game-badge">Desenvolvedora: <?php echo htmlspecialchars($developer); ?></span>
+                                    <span class="game-badge">Publisher: <?php echo htmlspecialchars($publisher); ?></span>
+                                    <span class="game-badge">Franquia: <?php echo htmlspecialchars($franchise); ?></span>
+                                    <span class="game-badge">Categoria: <?php echo htmlspecialchars($category); ?></span>
+                                </div>
+                                <p class="game-description"><?php echo htmlspecialchars($description); ?></p>
+                                <div class="game-price">Preço: <strong><?php echo htmlspecialchars($price); ?></strong></div>
+                            </div>
                         </div>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else : ?>
-        <p>Nenhum detalhe de jogo encontrado.</p>
-    <?php endif; ?>
-    <div class="mt-4">
-        <?php if ($page > 1) : ?>
-            <a href="?page=<?php echo $page - 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Anterior</a>
-        <?php endif; ?>
-        <?php if ($page < $total_pages) : ?>
-            <a href="?page=<?php echo $page + 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Próxima</a>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div class="friends-pagination">
+                <?php
+                    $maxVisible = 5;
+                    $halfWindow = floor($maxVisible / 2);
+                    $startPage = max(1, $page - $halfWindow);
+                    $endPage = min($total_pages, $startPage + $maxVisible - 1);
+
+                    if (($endPage - $startPage + 1) < $maxVisible) {
+                        $startPage = max(1, $endPage - $maxVisible + 1);
+                    }
+
+                    $hasPrev = $page > 1;
+                    $hasNext = $page < $total_pages;
+                ?>
+                <a class="pagination-btn <?php echo $hasPrev ? '' : 'disabled'; ?>" href="<?php echo $hasPrev ? '?page=' . ($page - 1) : 'javascript:void(0);'; ?>">Anterior</a>
+                <span class="pagination-separator">|</span>
+                <?php for ($p = $startPage; $p <= $endPage; $p++) : ?>
+                    <a class="pagination-btn <?php echo $p === $page ? 'active' : ''; ?>" href="?page=<?php echo $p; ?>"><?php echo $p; ?></a>
+                    <?php if ($p < $endPage) : ?>
+                        <span class="pagination-separator">|</span>
+                    <?php endif; ?>
+                <?php endfor; ?>
+                <span class="pagination-separator">|</span>
+                <a class="pagination-btn <?php echo $hasNext ? '' : 'disabled'; ?>" href="<?php echo $hasNext ? '?page=' . ($page + 1) : 'javascript:void(0);'; ?>">Próximo</a>
+            </div>
+        <?php else : ?>
+            <p class="text-green-50">Nenhum detalhe de jogo encontrado.</p>
         <?php endif; ?>
     </div>
-</div>
+</main>
+<script>
+    const pcSearchInput = document.getElementById('pcSearch');
+    const pcSearchButton = document.getElementById('pcSearchButton');
+    const pcList = document.getElementById('pcList');
+    const pcCards = pcList ? Array.from(pcList.querySelectorAll('.game-card')) : [];
+
+    function filterPcGames() {
+        const term = pcSearchInput.value.toLowerCase();
+        pcCards.forEach((card) => {
+            const title = card.getAttribute('data-title') || '';
+            card.style.display = title.includes(term) ? '' : 'none';
+        });
+    }
+
+    if (pcList) {
+        pcSearchInput.addEventListener('input', filterPcGames);
+        pcSearchButton.addEventListener('click', filterPcGames);
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/historico.php
+++ b/pages/historico.php
@@ -3,44 +3,199 @@
     include('../includes/header.php');
     include('../includes/navbar.php');
     require_once '../config/api.php';
+
     $endpoint = "activity/history";
     $response = openXBLRequest($endpoint);
     $activityItems = $response['activityItems'] ?? [];
 ?>
-<div class="container mx-auto mt-10">
-    <?php if (!empty($activityItems)): ?>
-        <ul class="bg-gray-800 p-4 rounded-lg shadow-md">
-            <?php foreach ($activityItems as $item): ?>
-                <li class="border-b border-gray-700 py-4">
-                    <div class="flex items-center">
-                        <img src="<?php echo $item['authorInfo']['imageUrl']; ?>" alt="Avatar" class="w-12 h-12 rounded-full mr-4">
-                        <div>
-                            <p class="text-lg font-bold text-green-400"><?php echo $item['authorInfo']['modernGamertag']; ?></p>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Histórico de Atividades</h1>
+            <p class="xbox-hero-subtitle">
+                Reviva suas capturas, clipes e marcos recentes em cartões de vidro líquido com navegação alinhada ao restante da experiência Xbox.
+            </p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="historySearch"
+                    placeholder="Buscar por Gamertag..."
+                    class="friends-search-input"
+                />
+                <button id="historySearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($activityItems)) : ?>
+            <div id="historyList" class="friend-grid">
+                <?php foreach ($activityItems as $item) : ?>
+                    <?php
+                        $author = $item['authorInfo'] ?? [];
+                        $avatar = !empty($author['imageUrl']) ? $author['imageUrl'] : '../img/default_avatar.jpg';
+                        $gamertag = $author['modernGamertag'] ?? 'Gamertag indisponível';
+                        $secondary = $author['secondName'] ?? 'Nome não disponível';
+                        $description = $item['description'] ?? 'Atividade';
+                        $shortDescription = $item['shortDescription'] ?? ($item['itemText'] ?? 'Sem detalhes adicionais');
+                        $timeline = $item['timeline']['timelineName'] ?? 'Histórico';
+                        $contentTitle = $item['contentTitle'] ?? 'Jogo desconhecido';
+                        $platform = $item['platform'] ?? 'Plataforma não informada';
+                        $dateRaw = $item['date'] ?? null;
+                        $formattedDate = $dateRaw ? date('d/m/Y H:i', strtotime($dateRaw)) : 'Data não disponível';
+                        $comments = isset($item['numComments']) ? $item['numComments'] : 'Sem comentários';
+                        $viewCount = isset($item['viewCount']) ? $item['viewCount'] : '0';
+                        $liked = !empty($item['hasLiked']);
+                        $media = $item['screenshotUri'] ?? ($item['contentImageUri'] ?? '');
+                    ?>
+                    <article class="friend-card xbox-glass-card activity-card" data-gamertag="<?php echo htmlspecialchars(strtolower($gamertag)); ?>">
+                        <div class="activity-card-header">
+                            <div class="friend-card-header">
+                                <span class="friend-status-dot"></span>
+                                <span class="friend-added">Registrado em <?php echo htmlspecialchars($timeline); ?></span>
+                            </div>
+                            <span class="activity-date">Publicado em <?php echo $formattedDate; ?></span>
                         </div>
-                    </div>
-                    <p class="mt-2 text-white"><strong><?php echo $item['description']; ?></strong></p>
-                    <p class="text-gray-400"><?php echo $item['shortDescription']; ?></p>
-                    <p class="text-gray-500 text-sm mt-1">Jogo: <?php echo $item['contentTitle']; ?></p>
-                    <p class="text-gray-500 text-sm">Plataforma:
-                        <?php if ($item['platform'] === 'Scarlett'): ?>
-                            <img src="../img/xboxseries.png" alt="Xbox Series" class="inline w-6 h-6">
-                        <?php else: ?>
-                            <?php echo $item['platform']; ?>
+                        <div class="activity-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo htmlspecialchars($avatar); ?>" alt="Avatar de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
+                            <div class="activity-details">
+                                <div class="activity-author">
+                                    <div class="friend-gamertag"><?php echo htmlspecialchars($gamertag); ?></div>
+                                    <div class="friend-presence"><?php echo htmlspecialchars($secondary); ?></div>
+                                </div>
+                                <div class="activity-description"><?php echo htmlspecialchars($description); ?></div>
+                                <div class="activity-text"><?php echo htmlspecialchars($shortDescription); ?></div>
+                                <div class="activity-meta">
+                                    <span>Jogo: <?php echo htmlspecialchars($contentTitle); ?></span>
+                                    <span>Plataforma: <?php echo htmlspecialchars($platform); ?></span>
+                                    <span>Visualizações: <?php echo htmlspecialchars($viewCount); ?></span>
+                                    <span>Comentários: <?php echo htmlspecialchars($comments); ?></span>
+                                    <span class="activity-like">Likes: <?php echo $liked ? '✔️' : '❌'; ?></span>
+                                </div>
+                            </div>
+                        </div>
+                        <?php if (!empty($media)) : ?>
+                            <div class="activity-media">
+                                <img src="<?php echo htmlspecialchars($media); ?>" alt="Mídia de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
                         <?php endif; ?>
-                    </p>
-                    <img src="<?php echo $item['screenshotUri']; ?>" alt="Screenshot" class="mt-2 rounded-lg shadow-lg w-full">
-                    <div class="flex justify-between items-center mt-2">
-                        <p class="text-gray-500 text-xs">Capturado em: <?php echo date('d/m/Y H:i', strtotime($item['date'])); ?></p>
-                    </div>
-                    <div class="flex mt-2 space-x-4">
-                        <p class="text-sm text-gray-400">Visualizações: <?php echo $item['viewCount']; ?></p>
-                        <p class="text-sm text-gray-400">Likes: <?php echo $item['hasLiked'] ? '✔️' : '❌'; ?></p>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else: ?>
-        <p class="text-gray-400">Nenhuma atividade disponível no histórico.</p>
-    <?php endif; ?>
-</div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="historyPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Nenhuma atividade disponível no histórico.</p>
+        <?php endif; ?>
+    </div>
+</main>
+<script>
+    const historySearchInput = document.getElementById('historySearch');
+    const historySearchButton = document.getElementById('historySearchButton');
+    const historyList = document.getElementById('historyList');
+    const historyPagination = document.getElementById('historyPagination');
+    const historyCards = historyList ? Array.from(historyList.querySelectorAll('.activity-card')) : [];
+    const PAGE_SIZE = 12;
+    let currentPage = 1;
+
+    function filterHistory() {
+        const term = historySearchInput.value.toLowerCase();
+        return historyCards.filter((card) => card.getAttribute('data-gamertag').includes(term));
+    }
+
+    function renderPagination(totalPages) {
+        historyPagination.innerHTML = '';
+        if (totalPages <= 1) return;
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    currentPage = page;
+                    updateHistory();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            historyPagination.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, currentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = currentPage > 1;
+        const hasNext = currentPage < totalPages;
+
+        historyPagination.appendChild(
+            createButton('Anterior', currentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            historyPagination.appendChild(createButton(page, page, { isActive: page === currentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        historyPagination.appendChild(
+            createButton('Próximo', currentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateHistory() {
+        if (!historyList) return;
+
+        const filtered = filterHistory();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+        currentPage = Math.min(currentPage, totalPages);
+
+        historyCards.forEach((card) => {
+            card.style.display = 'none';
+        });
+
+        const start = (currentPage - 1) * PAGE_SIZE;
+        const visible = filtered.slice(start, start + PAGE_SIZE);
+        visible.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderPagination(totalPages);
+    }
+
+    if (historyList) {
+        historySearchInput.addEventListener('input', () => {
+            currentPage = 1;
+            updateHistory();
+        });
+
+        historySearchButton.addEventListener('click', () => {
+            currentPage = 1;
+            updateHistory();
+        });
+
+        updateHistory();
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/jogos_sem_controle.php
+++ b/pages/jogos_sem_controle.php
@@ -15,7 +15,7 @@
         echo "Nenhum jogo encontrado no banco de dados.";
         exit;
     }
-    $items_per_page = 10;
+    $items_per_page = 12;
     $total_items = count($game_ids);
     $total_pages = ceil($total_items / $items_per_page);
     $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
@@ -27,61 +27,127 @@
     ];
     $response = openXBLPostRequest($endpoint, $body);
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Todos os Jogos do XCloud (Touch) </h1>
-    <?php if (!empty($response['Products'])) : ?>
-        <ul>
-            <?php foreach ($response['Products'] as $product) : ?>
-                <li class="mb-4">
-                    <div class="flex items-center space-x-4">
-                        <?php
-                            $boxArtImage = null;
-                            if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
-                                foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
-                                    if ($image['ImagePurpose'] === 'BoxArt') {
-                                        $boxArtImage = $image['Uri'];
-                                        break;
-                                    }
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Game Pass</span>
+            <h1 class="xbox-hero-title">Todos os Jogos do XCloud (Touch)</h1>
+            <p class="xbox-hero-subtitle">Descubra os jogos touch do XCloud com busca temática, cartões em vidro líquido e paginação consistente.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="cloudSearch"
+                    placeholder="Buscar por título..."
+                    class="friends-search-input"
+                />
+                <button id="cloudSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($response['Products'])) : ?>
+            <div id="cloudList" class="friend-grid">
+                <?php foreach ($response['Products'] as $product) : ?>
+                    <?php
+                        $boxArtImage = null;
+                        if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
+                            foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
+                                if ($image['ImagePurpose'] === 'BoxArt') {
+                                    $boxArtImage = $image['Uri'];
+                                    break;
                                 }
                             }
-                        ?>
-                        <?php if ($boxArtImage): ?>
-                            <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Imagem do jogo" class="w-16 h-16 rounded-full">
-                        <?php else: ?>
-                            <img src="../img/placeholder.png" alt="Imagem não disponível" class="w-16 h-16 rounded-full">
-                        <?php endif; ?>
-                        <div>
-                            <p class="text-xl"><?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">
-                                Preço:
-                                <?php
-                                    if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
-                                        echo '$' . number_format($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'], 2);
-                                    } else {
-                                        echo 'Não disponível';
-                                    }
-                                ?>
-                            </p>
-                            <p class="text-sm text-gray-400">Descrição: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Desenvolvedora: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Publisher: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Franquia: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Categoria: <?php echo htmlspecialchars($product['Properties']['Category'] ?? 'Não disponível'); ?></p>
+                        }
+
+                        $title = $product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível';
+                        $description = $product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível';
+                        $developer = $product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida';
+                        $publisher = $product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida';
+                        $franchise = $product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível';
+                        $category = $product['Properties']['Category'] ?? 'Não disponível';
+
+                        $price = 'Não disponível';
+                        if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
+                            $priceValue = $product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'];
+                            $price = '$' . number_format($priceValue, 2);
+                        }
+                    ?>
+                    <article class="friend-card xbox-glass-card game-card" data-title="<?php echo htmlspecialchars(strtolower($title)); ?>">
+                        <div class="game-card-body">
+                            <div class="game-cover">
+                                <?php if ($boxArtImage) : ?>
+                                    <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Capa de <?php echo htmlspecialchars($title); ?>">
+                                <?php else : ?>
+                                    <img src="../img/placeholder.png" alt="Imagem não disponível">
+                                <?php endif; ?>
+                            </div>
+                            <div class="game-details">
+                                <div class="game-title"><?php echo htmlspecialchars($title); ?></div>
+                                <div class="game-meta">
+                                    <span class="game-badge">Desenvolvedora: <?php echo htmlspecialchars($developer); ?></span>
+                                    <span class="game-badge">Publisher: <?php echo htmlspecialchars($publisher); ?></span>
+                                    <span class="game-badge">Franquia: <?php echo htmlspecialchars($franchise); ?></span>
+                                    <span class="game-badge">Categoria: <?php echo htmlspecialchars($category); ?></span>
+                                </div>
+                                <p class="game-description"><?php echo htmlspecialchars($description); ?></p>
+                                <div class="game-price">Preço: <strong><?php echo htmlspecialchars($price); ?></strong></div>
+                            </div>
                         </div>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else : ?>
-        <p>Nenhum detalhe de jogo encontrado.</p>
-    <?php endif; ?>
-    <div class="mt-4">
-        <?php if ($page > 1) : ?>
-            <a href="?page=<?php echo $page - 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Anterior</a>
-        <?php endif; ?>
-        <?php if ($page < $total_pages) : ?>
-            <a href="?page=<?php echo $page + 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Próxima</a>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div class="friends-pagination">
+                <?php
+                    $maxVisible = 5;
+                    $halfWindow = floor($maxVisible / 2);
+                    $startPage = max(1, $page - $halfWindow);
+                    $endPage = min($total_pages, $startPage + $maxVisible - 1);
+
+                    if (($endPage - $startPage + 1) < $maxVisible) {
+                        $startPage = max(1, $endPage - $maxVisible + 1);
+                    }
+
+                    $hasPrev = $page > 1;
+                    $hasNext = $page < $total_pages;
+                ?>
+                <a class="pagination-btn <?php echo $hasPrev ? '' : 'disabled'; ?>" href="<?php echo $hasPrev ? '?page=' . ($page - 1) : 'javascript:void(0);'; ?>">Anterior</a>
+                <span class="pagination-separator">|</span>
+                <?php for ($p = $startPage; $p <= $endPage; $p++) : ?>
+                    <a class="pagination-btn <?php echo $p === $page ? 'active' : ''; ?>" href="?page=<?php echo $p; ?>"><?php echo $p; ?></a>
+                    <?php if ($p < $endPage) : ?>
+                        <span class="pagination-separator">|</span>
+                    <?php endif; ?>
+                <?php endfor; ?>
+                <span class="pagination-separator">|</span>
+                <a class="pagination-btn <?php echo $hasNext ? '' : 'disabled'; ?>" href="<?php echo $hasNext ? '?page=' . ($page + 1) : 'javascript:void(0);'; ?>">Próximo</a>
+            </div>
+        <?php else : ?>
+            <p class="text-green-50">Nenhum detalhe de jogo encontrado.</p>
         <?php endif; ?>
     </div>
-</div>
+</main>
+<script>
+    const cloudSearchInput = document.getElementById('cloudSearch');
+    const cloudSearchButton = document.getElementById('cloudSearchButton');
+    const cloudList = document.getElementById('cloudList');
+    const cloudCards = cloudList ? Array.from(cloudList.querySelectorAll('.game-card')) : [];
+
+    function filterCloudGames() {
+        const term = cloudSearchInput.value.toLowerCase();
+        cloudCards.forEach((card) => {
+            const title = card.getAttribute('data-title') || '';
+            card.style.display = title.includes(term) ? '' : 'none';
+        });
+    }
+
+    if (cloudList) {
+        cloudSearchInput.addEventListener('input', filterCloudGames);
+        cloudSearchButton.addEventListener('click', filterCloudGames);
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/recentes.php
+++ b/pages/recentes.php
@@ -4,55 +4,195 @@
     include('../includes/navbar.php');
     require '../config/db.php';
     require_once '../config/api.php';
+
     if (!isset($_SESSION['user_id'])) {
         echo "Erro: Usuário não está logado.";
         exit;
     }
-    
+
     $endpoint = "recent-players";
     $response = openXBLRequest($endpoint);
-    
+
     if ($response && isset($response['people']) && is_array($response['people'])) {
         $recentPlayers = $response['people'];
     } else {
         $recentPlayers = [];
     }
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Jogadores Recentes</h1>
-    <?php if (!empty($recentPlayers)) : ?>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <?php foreach ($recentPlayers as $player) : ?>
-                <div class="bg-gray-800 text-white shadow-lg rounded-lg overflow-hidden flex">
-                    <div class="w-1/3 bg-gray-700 flex items-center justify-center">
-                        <?php
-                            $avatar = !empty($player['displayPicRaw']) ? $player['displayPicRaw'] : '../img/default_avatar.jpg';
-                        ?>
-                        <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($player['gamertag']); ?>" class="w-full h-full object-cover">
-                    </div>
-                    <div class="w-2/3 p-4 flex flex-col justify-between">
-                        <div>
-                            <h2 class="text-lg font-bold"><?php echo htmlspecialchars($player['gamertag']); ?></h2>
-                            <p class="text-sm text-gray-400 mt-1">Último jogo: <?php echo htmlspecialchars($player['recentPlayer']['titles'][0]['titleName']); ?></p>
-                            <p class="text-sm text-gray-400">Último encontro:
-                                <?php
-                                    $lastPlayed = isset($player['recentPlayer']['titles'][0]['lastPlayedWithDateTime']) ? date('d/m/Y', strtotime($player['recentPlayer']['titles'][0]['lastPlayedWithDateTime'])) : 'Data não disponível';
-                                    echo $lastPlayed;
-                                ?>
-                            </p>
-                        </div>
-                        <div class="mt-2">
-                            <p class="text-sm text-green-400 flex items-center">
-                                Gamerscore: <?php echo number_format($player['gamerScore'], 0, ',', '.'); ?>
-                                <img src="../img/gs.png" alt="Gamerscore Icon" class="inline-block ml-2 w-5 h-5">
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            <?php endforeach; ?>
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Comunidade</span>
+            <h1 class="xbox-hero-title">Jogadores Recentes</h1>
+            <p class="xbox-hero-subtitle">
+                Revise quem jogou com você recentemente com o mesmo visual líquido e controles de busca usados em Amigos e Bloqueados.
+            </p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="filterRecentGamertag"
+                    placeholder="Buscar por Gamertag..."
+                    class="friends-search-input"
+                />
+                <button id="recentSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
         </div>
-    <?php else : ?>
-        <p>Você não jogou com outros jogadores recentemente.</p>
-    <?php endif; ?>
-</div>
+
+        <?php if (!empty($recentPlayers)) : ?>
+            <div id="recentList" class="friend-grid">
+                <?php foreach ($recentPlayers as $player) : ?>
+                    <?php
+                        $avatar = !empty($player['displayPicRaw']) ? $player['displayPicRaw'] : '../img/default_avatar.jpg';
+                        $gamertag = $player['gamertag'] ?? ($player['displayName'] ?? 'Usuário');
+                        $recentTitle = $player['recentPlayer']['titles'][0]['titleName'] ?? 'Jogo recente não informado';
+                        $lastPlayedRaw = $player['recentPlayer']['titles'][0]['lastPlayedWithDateTime'] ?? null;
+                        $lastPlayed = $lastPlayedRaw ? date('d/m/Y', strtotime($lastPlayedRaw)) : 'Data não disponível';
+                        $gamerscore = isset($player['gamerScore']) ? number_format($player['gamerScore'], 0, ',', '.') : '0';
+                    ?>
+                    <article
+                        class="friend-card xbox-glass-card"
+                        data-gamertag="<?php echo htmlspecialchars($gamertag); ?>"
+                    >
+                        <div class="friend-card-header">
+                            <span class="friend-status-dot"></span>
+                            <span class="friend-added">Jogou recentemente</span>
+                        </div>
+                        <div class="friend-card-body">
+                            <div class="friend-avatar">
+                                <img src="<?php echo $avatar; ?>" alt="Avatar de <?php echo htmlspecialchars($gamertag); ?>" />
+                            </div>
+                            <div class="friend-details">
+                                <div class="friend-gamertag"><?php echo htmlspecialchars($gamertag); ?></div>
+                                <div class="friend-presence">Último jogo: <?php echo htmlspecialchars($recentTitle); ?></div>
+                                <div class="friend-presence">Último encontro: <?php echo htmlspecialchars($lastPlayed); ?></div>
+                                <div class="friend-gamerscore">
+                                    <span>Gamerscore</span>
+                                    <strong><?php echo $gamerscore; ?></strong>
+                                    <img src="../img/gs.png" alt="Gamerscore Icon" class="friend-gs-icon" />
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div id="recentPagination" class="friends-pagination"></div>
+        <?php else : ?>
+            <p class="text-green-50">Você não jogou com outros jogadores recentemente.</p>
+        <?php endif; ?>
+    </div>
+</main>
+<script>
+    const recentSearchInput = document.getElementById('filterRecentGamertag');
+    const recentSearchButton = document.getElementById('recentSearchButton');
+    const recentList = document.getElementById('recentList');
+    const recentPagination = document.getElementById('recentPagination');
+    const recentCards = recentList ? Array.from(recentList.querySelectorAll('.friend-card')) : [];
+    const RECENT_PAGE_SIZE = 12;
+    let recentCurrentPage = 1;
+
+    function applyRecentFilters() {
+        const gamertagTerm = recentSearchInput.value.toLowerCase();
+        return recentCards.filter((card) => {
+            const gamertag = card.getAttribute('data-gamertag').toLowerCase();
+            return gamertag.includes(gamertagTerm);
+        });
+    }
+
+    function renderRecentPagination(totalPages) {
+        recentPagination.innerHTML = '';
+        if (totalPages <= 1) {
+            return;
+        }
+
+        const createButton = (label, page, { isActive = false, disabled = false } = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.className = `pagination-btn ${isActive ? 'active' : ''} ${disabled ? 'disabled' : ''}`;
+            if (!disabled) {
+                button.addEventListener('click', () => {
+                    recentCurrentPage = page;
+                    updateRecent();
+                });
+            }
+            return button;
+        };
+
+        const addSeparator = () => {
+            const separator = document.createElement('span');
+            separator.className = 'pagination-separator';
+            separator.textContent = '|';
+            recentPagination.appendChild(separator);
+        };
+
+        const maxVisible = 5;
+        const halfWindow = Math.floor(maxVisible / 2);
+        let startPage = Math.max(1, recentCurrentPage - halfWindow);
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+
+        if (endPage - startPage + 1 < maxVisible) {
+            startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+
+        const hasPrev = recentCurrentPage > 1;
+        const hasNext = recentCurrentPage < totalPages;
+
+        recentPagination.appendChild(
+            createButton('Anterior', recentCurrentPage - 1, { disabled: !hasPrev })
+        );
+
+        addSeparator();
+
+        for (let page = startPage; page <= endPage; page++) {
+            recentPagination.appendChild(createButton(page, page, { isActive: page === recentCurrentPage }));
+            if (page < endPage) addSeparator();
+        }
+
+        addSeparator();
+
+        recentPagination.appendChild(
+            createButton('Próximo', recentCurrentPage + 1, { disabled: !hasNext })
+        );
+    }
+
+    function updateRecent() {
+        if (!recentList) return;
+
+        const filtered = applyRecentFilters();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / RECENT_PAGE_SIZE));
+        recentCurrentPage = Math.min(recentCurrentPage, totalPages);
+
+        recentCards.forEach((card) => {
+            card.style.display = 'none';
+        });
+
+        const start = (recentCurrentPage - 1) * RECENT_PAGE_SIZE;
+        const visibleCards = filtered.slice(start, start + RECENT_PAGE_SIZE);
+        visibleCards.forEach((card) => {
+            card.style.display = '';
+        });
+
+        renderRecentPagination(totalPages);
+    }
+
+    if (recentList) {
+        recentSearchInput.addEventListener('input', () => {
+            recentCurrentPage = 1;
+            updateRecent();
+        });
+
+        recentSearchButton.addEventListener('click', () => {
+            recentCurrentPage = 1;
+            updateRecent();
+        });
+
+        updateRecent();
+    }
+</script>
 <?php include('../includes/footer.php'); ?>

--- a/pages/todos_os_jogos.php
+++ b/pages/todos_os_jogos.php
@@ -4,84 +4,156 @@
     include('../includes/navbar.php');
     require '../config/db.php';
     require_once '../config/api.php';
+
     if (!isset($_SESSION['user_id'])) {
         echo "Erro: Usuário não está logado.";
         exit;
     }
+
     $stmt = $pdo->prepare("SELECT game_id FROM gamepass_games");
     $stmt->execute();
     $game_ids = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
     if (empty($game_ids)) {
         echo "Nenhum jogo encontrado no banco de dados.";
         exit;
     }
-    $items_per_page = 10;
+
+    $items_per_page = 12;
     $total_items = count($game_ids);
     $total_pages = ceil($total_items / $items_per_page);
     $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
     $offset = ($page - 1) * $items_per_page;
     $current_page_ids = array_slice($game_ids, $offset, $items_per_page);
+
     $endpoint = "marketplace/details";
     $body = [
         "products" => implode(',', $current_page_ids)
     ];
+
     $response = openXBLPostRequest($endpoint, $body);
 ?>
-<div class="container mx-auto p-4">
-    <h1 class="text-3xl mb-4">Todos os Jogos do Game Pass</h1>
-    <?php if (!empty($response['Products'])) : ?>
-        <ul>
-            <?php foreach ($response['Products'] as $product) : ?>
-                <li class="mb-4">
-                    <div class="flex items-center space-x-4">
-                        <?php
-                            $boxArtImage = null;
-                            if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
-                                foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
-                                    if ($image['ImagePurpose'] === 'BoxArt') {
-                                        $boxArtImage = $image['Uri'];
-                                        break;
-                                    }
+<main class="xbox-content">
+    <div class="xbox-page space-y-6">
+        <section class="xbox-hero">
+            <span class="xbox-hero-eyebrow">Game Pass</span>
+            <h1 class="xbox-hero-title">Todos os Jogos do Game Pass</h1>
+            <p class="xbox-hero-subtitle">Navegue pela biblioteca completa com cartões em vidro líquido, busca temática e paginação alinhada ao restante da experiência.</p>
+        </section>
+
+        <div class="xbox-panel space-y-4">
+            <div class="friends-search">
+                <i class="fas fa-search text-green-200/80"></i>
+                <input
+                    type="text"
+                    id="gamesSearch"
+                    placeholder="Buscar por título..."
+                    class="friends-search-input"
+                />
+                <button id="gamesSearchButton" class="friends-search-btn" aria-label="Buscar">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
+
+        <?php if (!empty($response['Products'])) : ?>
+            <div id="gamesList" class="friend-grid">
+                <?php foreach ($response['Products'] as $product) : ?>
+                    <?php
+                        $boxArtImage = null;
+                        if (isset($product['LocalizedProperties'][0]['Images']) && is_array($product['LocalizedProperties'][0]['Images'])) {
+                            foreach ($product['LocalizedProperties'][0]['Images'] as $image) {
+                                if ($image['ImagePurpose'] === 'BoxArt') {
+                                    $boxArtImage = $image['Uri'];
+                                    break;
                                 }
                             }
-                        ?>
-                        <?php if ($boxArtImage): ?>
-                            <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Imagem do jogo" class="w-16 h-16 rounded-full">
-                        <?php else: ?>
-                            <img src="../img/placeholder.png" alt="Imagem não disponível" class="w-16 h-16 rounded-full">
-                        <?php endif; ?>
-                        <div>
-                            <p class="text-xl"><?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">
-                                Preço:
-                                <?php
-                                    if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
-                                        echo '$' . number_format($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'], 2);
-                                    } else {
-                                        echo 'Não disponível';
-                                    }
-                                ?>
-                            </p>
-                            <p class="text-sm text-gray-400">Descrição: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Desenvolvedora: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Publisher: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida'); ?></p>
-                            <p class="text-sm text-gray-400">Franquia: <?php echo htmlspecialchars($product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível'); ?></p>
-                            <p class="text-sm text-gray-400">Categoria: <?php echo htmlspecialchars($product['Properties']['Category'] ?? 'Não disponível'); ?></p>
+                        }
+
+                        $title = $product['LocalizedProperties'][0]['ProductTitle'] ?? 'Título não disponível';
+                        $description = $product['LocalizedProperties'][0]['ProductDescription'] ?? 'Descrição não disponível';
+                        $developer = $product['LocalizedProperties'][0]['DeveloperName'] ?? 'Desconhecida';
+                        $publisher = $product['LocalizedProperties'][0]['PublisherName'] ?? 'Desconhecida';
+                        $franchise = $product['LocalizedProperties'][0]['Franchises'][0] ?? 'Não disponível';
+                        $category = $product['Properties']['Category'] ?? 'Não disponível';
+
+                        $price = 'Não disponível';
+                        if (isset($product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'])) {
+                            $priceValue = $product['DisplaySkuAvailabilities'][0]['OrderManagementData']['Price']['ListPrice'];
+                            $price = '$' . number_format($priceValue, 2);
+                        }
+                    ?>
+                    <article class="friend-card xbox-glass-card game-card" data-title="<?php echo htmlspecialchars(strtolower($title)); ?>">
+                        <div class="game-card-body">
+                            <div class="game-cover">
+                                <?php if ($boxArtImage) : ?>
+                                    <img src="<?php echo 'https:' . $boxArtImage; ?>" alt="Capa de <?php echo htmlspecialchars($title); ?>">
+                                <?php else : ?>
+                                    <img src="../img/placeholder.png" alt="Imagem não disponível">
+                                <?php endif; ?>
+                            </div>
+                            <div class="game-details">
+                                <div class="game-title"><?php echo htmlspecialchars($title); ?></div>
+                                <div class="game-meta">
+                                    <span class="game-badge">Desenvolvedora: <?php echo htmlspecialchars($developer); ?></span>
+                                    <span class="game-badge">Publisher: <?php echo htmlspecialchars($publisher); ?></span>
+                                    <span class="game-badge">Franquia: <?php echo htmlspecialchars($franchise); ?></span>
+                                    <span class="game-badge">Categoria: <?php echo htmlspecialchars($category); ?></span>
+                                </div>
+                                <p class="game-description"><?php echo htmlspecialchars($description); ?></p>
+                                <div class="game-price">Preço: <strong><?php echo htmlspecialchars($price); ?></strong></div>
+                            </div>
                         </div>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php else : ?>
-        <p>Nenhum detalhe de jogo encontrado.</p>
-    <?php endif; ?>
-    <div class="mt-4">
-        <?php if ($page > 1) : ?>
-            <a href="?page=<?php echo $page - 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Anterior</a>
-        <?php endif; ?>
-        <?php if ($page < $total_pages) : ?>
-            <a href="?page=<?php echo $page + 1; ?>" class="px-4 py-2 bg-gray-300 rounded">Próxima</a>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div class="friends-pagination">
+                <?php
+                    $maxVisible = 5;
+                    $halfWindow = floor($maxVisible / 2);
+                    $startPage = max(1, $page - $halfWindow);
+                    $endPage = min($total_pages, $startPage + $maxVisible - 1);
+
+                    if (($endPage - $startPage + 1) < $maxVisible) {
+                        $startPage = max(1, $endPage - $maxVisible + 1);
+                    }
+
+                    $hasPrev = $page > 1;
+                    $hasNext = $page < $total_pages;
+                ?>
+                <a class="pagination-btn <?php echo $hasPrev ? '' : 'disabled'; ?>" href="<?php echo $hasPrev ? '?page=' . ($page - 1) : 'javascript:void(0);'; ?>">Anterior</a>
+                <span class="pagination-separator">|</span>
+                <?php for ($p = $startPage; $p <= $endPage; $p++) : ?>
+                    <a class="pagination-btn <?php echo $p === $page ? 'active' : ''; ?>" href="?page=<?php echo $p; ?>"><?php echo $p; ?></a>
+                    <?php if ($p < $endPage) : ?>
+                        <span class="pagination-separator">|</span>
+                    <?php endif; ?>
+                <?php endfor; ?>
+                <span class="pagination-separator">|</span>
+                <a class="pagination-btn <?php echo $hasNext ? '' : 'disabled'; ?>" href="<?php echo $hasNext ? '?page=' . ($page + 1) : 'javascript:void(0);'; ?>">Próximo</a>
+            </div>
+        <?php else : ?>
+            <p class="text-green-50">Nenhum detalhe de jogo encontrado.</p>
         <?php endif; ?>
     </div>
-</div>
+</main>
+<script>
+    const gamesSearchInput = document.getElementById('gamesSearch');
+    const gamesSearchButton = document.getElementById('gamesSearchButton');
+    const gamesList = document.getElementById('gamesList');
+    const gameCards = gamesList ? Array.from(gamesList.querySelectorAll('.game-card')) : [];
+
+    function filterGames() {
+        const term = gamesSearchInput.value.toLowerCase();
+        gameCards.forEach((card) => {
+            const title = card.getAttribute('data-title') || '';
+            card.style.display = title.includes(term) ? '' : 'none';
+        });
+    }
+
+    if (gamesList) {
+        gamesSearchInput.addEventListener('input', filterGames);
+        gamesSearchButton.addEventListener('click', filterGames);
+    }
+</script>
 <?php include('../includes/footer.php'); ?>


### PR DESCRIPTION
## Summary
- restyle EA Play, XCloud touch, and PC Game Pass listings with the Xbox hero, search bar, and glass game cards
- set pagination to show 12 items per page with five-link windows and themed controls consistent with other pages
- add client-side title search filtering for each catalog page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ba26d99c832693b5f9d91f36d389)